### PR TITLE
Update badges to refer to their respective jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-devfile-registry-build-master/)](https://ci.centos.org/job/devtools-che-devfile-registry-build-master/)
-[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-devfile-registry-nightly/)](https://ci.centos.org/job/devtools-che-devfile-registry-nightly/)
-[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-devfile-registry-release/)](https://ci.centos.org/job/devtools-che-devfile-registry-release/)
-[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-che-devfile-registry-release-preview/)](https://ci.centos.org/job/devtools-che-devfile-registry-release-preview/)
+[![Master Build Status](https://ci.centos.org/buildStatus/icon?subject=master&job=devtools-che-devfile-registry-build-master/)](https://ci.centos.org/job/devtools-che-devfile-registry-build-master/)
+[![Nightly Build Status](https://ci.centos.org/buildStatus/icon?subject=nightly&job=devtools-che-devfile-registry-nightly/)](https://ci.centos.org/job/devtools-che-devfile-registry-nightly/)
+[![Release Build Status](https://ci.centos.org/buildStatus/icon?subject=release&job=devtools-che-devfile-registry-release/)](https://ci.centos.org/job/devtools-che-devfile-registry-release/)
+[![Preview Release Build Status](https://ci.centos.org/buildStatus/icon?subject=release-preview&job=devtools-che-devfile-registry-release-preview/)](https://ci.centos.org/job/devtools-che-devfile-registry-release-preview/)
 
 # Eclipse Che devfile registry
 


### PR DESCRIPTION
### What does this PR do?
Updates the badges on README.md to refer to their jobs rather than "Build":

Old:
![Old Screenshot](https://user-images.githubusercontent.com/16168279/63798925-fb880f80-c8d8-11e9-9a46-a388a7703fe8.png)

New:
![New Screenshot](https://user-images.githubusercontent.com/16168279/63798968-18244780-c8d9-11e9-8a9e-e8c86c3e64a9.png)



### What issues does this PR fix or reference?
Minor doc fixup.