### PR TITLE
Quarkus devfile: add more memory for native compilation

### DIFF
--- a/devfiles/quarkus/devfile.yaml
+++ b/devfiles/quarkus/devfile.yaml
@@ -25,7 +25,7 @@ components:
           -Duser.home=/home/user"
       - name: MAVEN_OPTS
         value: $(JAVA_OPTS)  
-    memoryLimit: 4Gi
+    memoryLimit: 4927M
     mountSources: true
     volumes:
       - name: m2
@@ -72,7 +72,7 @@ commands:
       -
         type: exec
         component: centos-quarkus-maven
-        command: "./mvnw package -Dnative"
+        command: "./mvnw package -Dnative -Dmaven.test.skip"
         workdir: ${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started
 
   -


### PR DESCRIPTION
### What does this PR do?
Setting to 4927M: it looks like Quarkus 1.5.0-Final needs more memory to perform the native comp (tested on che.openshift.io). 
also skipping tests
