### PR TITLE
feature(disk cleanup) use --rm flag to purge images from local docker registry after pushing to remote

### DIFF
--- a/.github/workflows/nightly-build-publish.yml
+++ b/.github/workflows/nightly-build-publish.yml
@@ -59,10 +59,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and push base images
-        run: ./arbitrary-users-patch/build_images.sh --push
+        run: ./arbitrary-users-patch/build_images.sh --push --rm
 
       - name: Build and push happy path image
-        run: ./arbitrary-users-patch/happy-path/build_happy_path_image.sh --push
+        run: ./arbitrary-users-patch/happy-path/build_happy_path_image.sh --push --rm
       -
         name: "Build and push"
         uses: docker/build-push-action@v2

--- a/arbitrary-users-patch/happy-path/build_happy_path_image.sh
+++ b/arbitrary-users-patch/happy-path/build_happy_path_image.sh
@@ -23,8 +23,13 @@ TAG=${TAG:-${DEFAULT_TAG}}
 NAME_FORMAT="${REGISTRY}/${ORGANIZATION}"
 
 PUSH_IMAGES=false
-if [ "$1" == "--push" ]; then
+if [ "$1" == "--push" ] || [ "$2" == "--push" ]; then
   PUSH_IMAGES=true
+fi
+
+RM_IMAGES=false
+if [ "$1" == "--rm" ] || [ "$2" == "--rm" ]; then
+  RM_IMAGES=true
 fi
 
 # Build image for happy-path tests with precashed mvn dependencies
@@ -32,4 +37,8 @@ docker build -t "${NAME_FORMAT}/happy-path:${TAG}" --no-cache --build-arg TAG="$
 if ${PUSH_IMAGES}; then
     echo "Pushing ${NAME_FORMAT}/happy-path:${TAG}" to remote registry
     docker push "${NAME_FORMAT}/happy-path:${TAG}" | cat
+fi
+if ${RM_IMAGES}; then # save disk space by deleting the image we just published
+  echo "Deleting${NAME_FORMAT}/happy-path:${TAG} from local registry"
+  docker rmi "${NAME_FORMAT}/happy-path:${TAG}"
 fi

--- a/make-release.sh
+++ b/make-release.sh
@@ -34,8 +34,8 @@ performRelease()
   #Build and push patched base images and happy path image
   TAG=$(head -n 1 VERSION)
   export TAG
-  ./arbitrary-users-patch/happy-path/build_happy_path_image.sh --push
-  ./arbitrary-users-patch/build_images.sh --push
+  ./arbitrary-users-patch/happy-path/build_happy_path_image.sh --push --rm
+  ./arbitrary-users-patch/build_images.sh --push --rm
 
   #Build and push images
   PLATFORMS="$(cat PLATFORMS)"


### PR DESCRIPTION
### What does this PR do?

use --rm flag to purge images from local docker registry after they're pushed to remote

Change-Id: Ibf077cba35048b3bc72b7d4025eef5ffbd0f191c
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

last week we ran out of disk building the che-devfile-registry's stack/sidecar images. This seeks to improve that problem by deleting images from the local registry after we've pushed them to quay.

If building locally is a common usecase (outside of GH actions) we might want to refactor things a bit so that the `--rm` flag is an optional one passed to make-release.sh, rather than being a default setting when make-release.sh calls into the `arbitrary-users-patch` scripts. 

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.