### PR TITLE
chore(dog-fooding-extend): allow other repos that contain only devfiles folder to reuse the che-plugin-registry dogfooding scripts

### DIFF
--- a/build/dev/build-devfile-registry.sh
+++ b/build/dev/build-devfile-registry.sh
@@ -14,11 +14,17 @@ BUILD_DIR=${BUILD_DIR:-$DEFAULT_BUILD_DIR}
 DEFAULT_REPO_DIR="/projects/che-devfile-registry"
 REPO_DIR=${REPO_DIR:-$DEFAULT_REPO_DIR}
 
+DEFAULT_BASE_IMAGES_SRC="$REPO_DIR/arbitrary-users-patch/base_images"
+BASE_IMAGES_SRC=${BASE_IMAGES_SRC:-$DEFAULT_BASE_IMAGES_SRC}
+
+DEFAULT_DEVFILES_SRC="$REPO_DIR/devfiles"
+DEVFILES_SRC=${DEVFILES_SRC:-$DEFAULT_DEVFILES_SRC}
+
 rm "$BUILD_DIR" -rf;
 
 cp -rf "$REPO_DIR"/build/scripts "$BUILD_DIR"
-cp -rf "$REPO_DIR"/arbitrary-users-patch/base_images "$BUILD_DIR"
-cp -rf "$REPO_DIR"/devfiles "$BUILD_DIR"/devfiles
+cp -rf "$BASE_IMAGES_SRC" "$BUILD_DIR"
+cp -rf "$DEVFILES_SRC" "$BUILD_DIR"/devfiles
 cd "$BUILD_DIR"
 ./check_mandatory_fields.sh devfiles
 ./index.sh > devfiles/index.json

--- a/build/dev/publish-devfile-registry-to-surge.sh
+++ b/build/dev/publish-devfile-registry-to-surge.sh
@@ -17,12 +17,15 @@ SURGE_DIR=${SURGE_DIR:-$DEFAULT_SURGE_DIR}
 DEFAULT_REPO_DIR="/projects/che-devfile-registry"
 REPO_DIR=${REPO_DIR:-$DEFAULT_REPO_DIR}
 
+DEFAULT_IMAGES_SRC="$REPO_DIR/images"
+IMAGES_SRC=${IMAGES_SRC:-$DEFAULT_IMAGES_SRC}
+
 rm "$SURGE_DIR" -rf;
 mkdir -p "$SURGE_DIR"/images
 cd "$SURGE_DIR"
 echo '*' > CORS
 cp -rf "$BUILD_DIR/devfiles" "$SURGE_DIR/devfiles"
-cp -rf "$REPO_DIR"/images/* "$SURGE_DIR/images"
+cp -rf "$IMAGES_SRC"/* "$SURGE_DIR/images"
 
 CHE_DEVFILE_REGISTRY_URL="https://$CHE_WORKSPACE_NAMESPACE-$CHE_WORKSPACE_NAME.surge.sh"
 DEVFILES_DIR=${SURGE_DIR}/devfiles

--- a/build/dev/start-devfile-registry.sh
+++ b/build/dev/start-devfile-registry.sh
@@ -14,11 +14,15 @@ BUILD_DIR=${BUILD_DIR:-$DEFAULT_BUILD_DIR}
 DEFAULT_REPO_DIR="/projects/che-devfile-registry"
 REPO_DIR=${REPO_DIR:-$DEFAULT_REPO_DIR}
 
+DEFAULT_IMAGES_SRC="$REPO_DIR/images"
+IMAGES_SRC=${IMAGES_SRC:-$DEFAULT_IMAGES_SRC}
+
+
 rm -rf /usr/local/apache2/htdocs/devfiles
 rm -rf /usr/local/apache2/htdocs/images/* 
 
 cp -rf "$BUILD_DIR"/devfiles /usr/local/apache2/htdocs/devfiles
-cp -rf "$REPO_DIR"/images/* /usr/local/apache2/htdocs/images
+cp -rf "$IMAGES_SRC"/* /usr/local/apache2/htdocs/images
 CHE_DEVFILE_REGISTRY_URL=$(cat "$BUILD_DIR"/ENV_CHE_DEVFILE_REGISTRY_URL)
 export CHE_DEVFILE_REGISTRY_URL
 echo "$CHE_DEVFILE_REGISTRY_URL"


### PR DESCRIPTION
Signed-off-by: Sun Tan <sutan@redhat.com>

### What does this PR do?
Allow other devfile registries git repo to reuse the same dogfooding scripts to build and publish.
For instance CRW or this one https://github.com/sunix/devfiles

### Screenshot/screencast of this PR
An example of dashboard using multiple devfile registries built with these scripts:
![Selection_329](https://user-images.githubusercontent.com/650571/115067022-9db29c00-9ef0-11eb-95e2-b3ca65ab2963.png)



### What issues does this PR fix or reference?
Not related, but used this to mockup https://github.com/eclipse/che/issues/18473
Part of https://github.com/eclipse/che/issues/19305

### How to test this PR?
Could be tested with the default dogfooding devfile: make sure build works
Could also be tested with https://github.com/sunix/devfiles/blob/master/devfile.yaml but changing the upstream repo with this branch
I tested days ago with CRW but did not push the devfile :(

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
