### PR TITLE
Adding support to provide external base_images file

### DIFF
--- a/arbitrary-users-patch/build_images.sh
+++ b/arbitrary-users-patch/build_images.sh
@@ -15,10 +15,12 @@ SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 DEFAULT_REGISTRY="quay.io"
 DEFAULT_ORGANIZATION="eclipse"
 DEFAULT_TAG="nightly"
+DEFAULT_BASE_IMAGES="${SCRIPT_DIR}/base_images"
 
 REGISTRY=${REGISTRY:-${DEFAULT_REGISTRY}}
 ORGANIZATION=${ORGANIZATION:-${DEFAULT_ORGANIZATION}}
 TAG=${TAG:-${DEFAULT_TAG}}
+BASE_IMAGES=${BASE_IMAGES:-${DEFAULT_BASE_IMAGES}}
 
 NAME_FORMAT="${REGISTRY}/${ORGANIZATION}"
 
@@ -48,7 +50,7 @@ while read -r line; do
     docker rmi "${NAME_FORMAT}/${dev_container_name}:${TAG}"
   fi
   BUILT_IMAGES="${BUILT_IMAGES}    ${NAME_FORMAT}/${dev_container_name}:${TAG}\n"
-done < "${SCRIPT_DIR}"/base_images
+done < ${BASE_IMAGES}
 
 echo "Built images:"
 echo -e "$BUILT_IMAGES"

--- a/arbitrary-users-patch/build_images.sh
+++ b/arbitrary-users-patch/build_images.sh
@@ -50,7 +50,7 @@ while read -r line; do
     docker rmi "${NAME_FORMAT}/${dev_container_name}:${TAG}"
   fi
   BUILT_IMAGES="${BUILT_IMAGES}    ${NAME_FORMAT}/${dev_container_name}:${TAG}\n"
-done < ${BASE_IMAGES}
+done < "${BASE_IMAGES}"
 
 echo "Built images:"
 echo -e "$BUILT_IMAGES"


### PR DESCRIPTION
### What does this PR do?
This PR adds support for an external `base_images` file in script `build_images.sh`.  My organization is creating custom dev containers (`dockerimage` components in devfiles) and I would like to benefit from the `entrypoint.sh` and modifications done by `arbitrary-users-patch/Dockerfile`.  But because the `base_image` file is hardcoded in the script, I cannot inject my own.  This PR adds a variable to do this.  The code is backward compatible, so no change is needed on your side.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
