### PR TITLE
fix(gh-pages): publish only if devfiles have changed

### DIFF
--- a/.ci/generate_and_publish_registry_url_devfiles.sh
+++ b/.ci/generate_and_publish_registry_url_devfiles.sh
@@ -80,5 +80,9 @@ cd ./che-devfile-registry
 # Copy generated devfiles and commit + push
 cp -rf /tmp/content/"${VERSION}" ./
 git add ./"${VERSION}"
-git commit -m "Publish devfile registry $VERSION - $(date)" -s
-git push "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/eclipse-che/che-devfile-registry.git" gh-pages
+if git diff --quiet; then
+    echo "No changes made, nothing to publish."
+else
+    git commit -m "Publish devfile registry $VERSION - $(date)" -s
+    git push "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/eclipse-che/che-devfile-registry.git" gh-pages
+fi


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Checks to see if any changes have been made before publishing to GitHub pages.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Failing publish job, i.e. https://github.com/eclipse-che/che-devfile-registry/runs/2895644565?check_suite_focus=true

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Try locally to publish without making any changes -- it should fail.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
