### PR TITLE
chore(make release): check the images existence sequentially (not in parallel)

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -37,13 +37,13 @@ verifyContainerExistsWithTimeout()
   count=1
   (( timeout_intervals=this_timeout*3 ))
   while [[ $count -le $timeout_intervals ]]; do # echo $count
-    echo "       [$count/$timeout_intervals] Verify ${container_to_check} exists..." 
+    echo "[INFO] [$count/$timeout_intervals] Verify ${container_to_check} exists..." 
     # check if the container exists
     verifyContainerExists "${container_to_check}"
 
     # container exists
     if [[ ${containerExists} -eq 1 ]]; then
-      exit 0
+      return
     fi
 
     # -1 indicates, that server didn't found the container and replied with message "UNKNOWN MANIFEST"
@@ -114,14 +114,12 @@ checkRequiredImagesExist()
         if [ -n "${images}" ]; then
           images="${images//image: /}"
           for image in ${images} ; do
-            verifyContainerExistsWithTimeout "${image}" 1 &
+            verifyContainerExistsWithTimeout "${image}" 1
           done
         fi
 
       fi
   done
-
-  wait
 }
 
 performRelease() 
@@ -135,9 +133,11 @@ performRelease()
   # Build and push happy path image, which depends on the above
   ./happy-path/build_happy_path_image.sh --push --rm
   
+  echo "[INFO] Checking images..."
   checkRequiredImagesExist
 
   #Build and push images
+  echo "[INFO] Build Revfile Registry Image..."
   PLATFORMS="$(cat PLATFORMS)"
   IMAGE=che-devfile-registry
   VERSION=$(head -n 1 VERSION)


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
It's not clear why the build script fails https://github.com/eclipse-che/che-devfile-registry/runs/3951923478?check_suite_focus=true#step:10:45542

This fixup will run checking of necessary docker images sequentially. This hopefully will help to catch the error.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Path of https://github.com/eclipse/che/issues/19695

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Run the make-release script locally.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
