### PR TITLE
fix: better recovery from a failed skopeo...

### DIFF
--- a/dockerfiles/golang-1.17/Dockerfile
+++ b/dockerfiles/golang-1.17/Dockerfile
@@ -9,6 +9,6 @@
 
 ARG BASE_IMAGE="docker.io/golang:1.17-stretch"
 
-FROM docker.io/golang@sha256:a49b4952c45d08591cb837a2c9c9385852fd4d2912007406c6b4417d75833521
+FROM docker.io/golang@sha256:2996c0e10f27cd7d3e2c1ac4badf80f423c81793540b4af89b3d75331ee22597
 
 #{INCLUDE:../base.dockerfile}


### PR DESCRIPTION
### What does this PR do?

fix: better recovery from a failed skopeo inspect -- try again and if not resolved after 2 attempts, DON'T CHANGE the digest to a nullstring

Change-Id: Ic65d99256542b646eb7f3e64f404f40071edab72
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
Avoids this problem:
https://github.com/eclipse-che/che-devfile-registry/pull/526/files#diff-d567d4dc0d879e5b1da3a21d592817871f3651f034a8d3c5d444a18a71ba243eR12

### How to test this PR?

1. Edit this file: ` che-devfiles-registry/dockerfiles/antora-2.3/Dockerfile`
2. set an invalid BASE_IMAGE address like `ARG BASE_IMAGE="docker.io/antora/antFFora:2.3.3"`
3. run `./build/workflows/check-sidecar-image-digests.sh`

After 30 seconds, no change will be applied to the registry and the processing of other Dockerfiles will continue. \o/

To prove that it WILL change when it DOES find a different latest digest:

1. Edit this file: ` che-devfiles-registry/dockerfiles/antora-2.3/Dockerfile`
2. set a different SHA, like `FROM docker.io/antora/antora@sha256:f00barf`
3. run `./build/workflows/check-sidecar-image-digests.sh`

Watch as the file is changed and your bad digest is reverted to a valid one. \o/ 

If you let the script run its course you should see ONE file changed: `dockerfiles/golang-1.17/Dockerfile`

https://github.com/eclipse-che/che-devfile-registry/pull/526/files#diff-8f51fac72ac1fc135355f5eaabe8e7984b6f79048c983e55dd78ca94d040677dR12

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.