### PR TITLE
fix: #20880 instead of a separate stage for...

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-FROM docker.io/alpine:3.11.5 AS builder
+FROM docker.io/node:16.13.0-alpine3.14 AS builder
 RUN apk add --no-cache py-pip jq bash wget git skopeo && pip install yq
 
 COPY ./build/scripts /build/
@@ -17,13 +17,8 @@ RUN ./check_mandatory_fields.sh devfiles
 
 RUN ./index.sh > /build/devfiles/index.json
 RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
-RUN chmod -R g+rwX /build/devfiles
-
-FROM docker.io/node:16.13.0-alpine3.14 as dwtemplates
-COPY ./build/scripts /build/
-COPY ./devfiles /build/devfiles
-WORKDIR /build/
 RUN ./generate_devworkspace_templates.sh
+RUN chmod -R g+rwX /build/devfiles
 
 FROM docker.io/httpd:2.4.43-alpine AS registry
 RUN apk add --no-cache bash && \
@@ -37,12 +32,11 @@ RUN apk add --no-cache bash && \
     apk add --no-cache coreutils
 COPY .htaccess README.md /usr/local/apache2/htdocs/
 COPY --from=builder /build/devfiles /usr/local/apache2/htdocs/devfiles
-COPY --from=dwtemplates /build/out /usr/local/apache2/htdocs/devfiles
+COPY --from=builder /build/out /usr/local/apache2/htdocs/devfiles
 COPY ./images /usr/local/apache2/htdocs/images
 COPY ./build/dockerfiles/entrypoint.sh /usr/bin/
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 CMD ["httpd-foreground"]
-
 
 # Offline registry: download project zips and place them in /build/resources
 FROM builder AS offline-builder


### PR DESCRIPTION
### What does this PR do?

fix: [#20880](https://github.com/eclipse/che/issues/20880) instead of a separate stage for dwtemplates, just use the node16 image as the builder, and then we don't have to repeat the same several steps in a new container... and don't have to fix perms in /devfiles/ folder either

Added bonuses to this fix:
* updateBaseImages can be run for ubi8/nodejs-16-minimal to keep it current (instead of the outdated ubi8-minimal:8.4, which should be on 8.5 now)
* downstreaming doesn't require new logic for dealing with the dwtemplates stage (downstream can't do several multipel stages, only 2 (build, runtime).

Change-Id: Ib61cfe1548e73ed2a8225596088250248b907c50
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20880

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.