### PR TITLE
feat: Update zip location for prebuilt samples with internal URL

### DIFF
--- a/.ci/generate_and_publish_registry_url_devfiles.sh
+++ b/.ci/generate_and_publish_registry_url_devfiles.sh
@@ -63,8 +63,10 @@ ${BUILDER} cp devfileRegistry:/var/www/html/README.md /tmp/content/"${VERSION}"
 
 # Run entrypoint
 CHE_DEVFILE_REGISTRY_URL="https://eclipse-che.github.io/che-devfile-registry/${VERSION}"
+CHE_DEVFILE_REGISTRY_INTERNAL_URL="https://eclipse-che.github.io/che-devfile-registry/${VERSION}"
 DEVFILES_DIR=/tmp/content/"${VERSION}"/devfiles
 export CHE_DEVFILE_REGISTRY_URL
+export CHE_DEVFILE_REGISTRY_INTERNAL_URL
 export DEVFILES_DIR
 ./build/dockerfiles/entrypoint.sh
 

--- a/build/dev/publish-devfile-registry-to-surge.sh
+++ b/build/dev/publish-devfile-registry-to-surge.sh
@@ -28,9 +28,11 @@ cp -rf "$BUILD_DIR/devfiles" "$SURGE_DIR/devfiles"
 cp -rf "$IMAGES_SRC"/* "$SURGE_DIR/images"
 
 CHE_DEVFILE_REGISTRY_URL="https://$CHE_WORKSPACE_NAMESPACE-$CHE_WORKSPACE_NAME.surge.sh"
+CHE_DEVFILE_REGISTRY_INTERNAL_URL="https://$CHE_WORKSPACE_NAMESPACE-$CHE_WORKSPACE_NAME.surge.sh"
 DEVFILES_DIR=${SURGE_DIR}/devfiles
 
 export CHE_DEVFILE_REGISTRY_URL
+export CHE_DEVFILE_REGISTRY_INTERNAL_URL
 export DEVFILES_DIR
 "$REPO_DIR/build/dockerfiles/entrypoint.sh" echo "done running entrypoint.sh to publish to surge"
 

--- a/build/dev/start-devfile-registry.sh
+++ b/build/dev/start-devfile-registry.sh
@@ -24,7 +24,9 @@ rm -rf /usr/local/apache2/htdocs/images/*
 cp -rf "$BUILD_DIR"/devfiles /usr/local/apache2/htdocs/devfiles
 cp -rf "$IMAGES_SRC"/* /usr/local/apache2/htdocs/images
 CHE_DEVFILE_REGISTRY_URL=$(cat "$BUILD_DIR"/ENV_CHE_DEVFILE_REGISTRY_URL)
+CHE_DEVFILE_REGISTRY_INTERNAL_URL="${CHE_DEVFILE_REGISTRY_URL}"
 export CHE_DEVFILE_REGISTRY_URL
+export CHE_DEVFILE_REGISTRY_INTERNAL_URL
 echo "$CHE_DEVFILE_REGISTRY_URL"
 /projects/che-devfile-registry/build/dockerfiles/entrypoint.sh echo "Starting Apache ..."
 httpd-foreground

--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -30,6 +30,7 @@ REGISTRY=${CHE_DEVFILE_IMAGES_REGISTRY_URL}
 ORGANIZATION=${CHE_DEVFILE_IMAGES_REGISTRY_ORGANIZATION}
 TAG=${CHE_DEVFILE_IMAGES_REGISTRY_TAG}
 PUBLIC_URL=${CHE_DEVFILE_REGISTRY_URL}
+INTERNAL_URL=${CHE_DEVFILE_REGISTRY_INTERNAL_URL}
 
 DEFAULT_DEVFILES_DIR="/var/www/html/devfiles"
 DEVFILES_DIR="${DEVFILES_DIR:-${DEFAULT_DEVFILES_DIR}}"
@@ -134,6 +135,12 @@ for devfile in "${devfiles[@]}"; do
     sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$devfile"
   fi
 done
+
+if [ -n "$INTERNAL_URL" ]; then
+  INTERNAL_URL=${INTERNAL_URL%/}
+  echo "Updating internal URL in files to ${INTERNAL_URL}"
+  sed -i "s|{{ INTERNAL_URL }}|${INTERNAL_URL}|" "${devfiles[@]}" "${metas[@]}" "${templates[@]}" "$INDEX_JSON"
+fi
 
 if [ -n "$PUBLIC_URL" ]; then
   echo "Updating devfiles to point at internal project zip files"

--- a/build/scripts/generate_devworkspace_templates.sh
+++ b/build/scripts/generate_devworkspace_templates.sh
@@ -26,12 +26,12 @@ do
 
     npm_config_yes=true npx @eclipse-che/che-theia-devworkspace-handler --devfile-url:"${devfile_url}" \
     --output-file:"${dir}"/devworkspace-che-theia-next.yaml \
-    --project."${name}={{ DEVFILE_REGISTRY_URL }}/resources/v2/${name}.zip"
+    --project."${name}={{ INTERNAL_URL }}/resources/v2/${name}.zip"
 
     npm_config_yes=true npx @eclipse-che/che-theia-devworkspace-handler --devfile-url:"${devfile_url}" \
     --editor:eclipse/che-theia/latest \
     --output-file:"${dir}"/devworkspace-che-theia-latest.yaml \
-    --project."${name}={{ DEVFILE_REGISTRY_URL }}/resources/v2/${name}.zip"
+    --project."${name}={{ INTERNAL_URL }}/resources/v2/${name}.zip"
 
     clone_and_zip "${devfile_repo}" "${devfile_url##*/}" "/build/resources/v2/$name.zip"
   fi


### PR DESCRIPTION
### What does this PR do?
It avoids proxy/TLS/untrusted issue
related to https://github.com/eclipse/che/issues/20709


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20709

### How to test this PR?
(make sure your che operator is the nightly one including this fix: https://github.com/eclipse-che/che-operator/pull/1237)

Then open devfile registry with a browser to something like
`https://che-url/devfile-registry/devfiles/go/devworkspace-che-theia-latest.yaml`

see that the zip location is using `http://devfile-registry.eclipse-che.svc:8080/resources/v2/golang-echo-example.zip`

You can go inside for example dashboard container and do:
```
$ wget http://devfile-registry.eclipse-che.svc:8080/resources/v2/golang-echo-example.zip
```

file is downloaded as expected

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: Ic39fa9928c4f86ff4543117a9092f0cadb0457bd
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
