### PR TITLE
fix: add list of used images into external_images.txt

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -19,8 +19,8 @@ WORKDIR /build/
 RUN ./check_mandatory_fields.sh devfiles
 
 RUN ./index.sh > /build/devfiles/index.json
-RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
 RUN ./generate_devworkspace_templates.sh $VERSION
+RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
 RUN chmod -R g+rwX /build/devfiles
 RUN chmod -R g+rwX /build/resources
 

--- a/build/scripts/list_referenced_images.sh
+++ b/build/scripts/list_referenced_images.sh
@@ -12,7 +12,7 @@
 
 set -e
 
-readarray -d '' devfiles < <(find "$1" -name 'devfile.yaml' -print0)
+readarray -d '' devfiles < <(find "$1" \( -name 'devfile.yaml' -o -name 'devworkspace-*.yaml' \) -print0)
 yq -r '..|.image?' "${devfiles[@]}" | grep -v "null" | sort | uniq
 # include images from referenced kubernetes content.
 for devfile in "${devfiles[@]}"; do


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Get used images from devworkspace-templates*.yaml files

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21574

### How to test this PR?
build devfile registry and check **/usr/local/apache2/htdocs/devfiles/external_images.txt** file, it should contain the list of images
