### PR TITLE
chore: theia/next is dead, remove it from...

### DIFF
--- a/build/dockerfiles/entrypoint.sh
+++ b/build/dockerfiles/entrypoint.sh
@@ -151,7 +151,6 @@ if [ -n "$PUBLIC_URL" ]; then
   sed -i "s|\"icon\": \"/images/|\"icon\": \"${PUBLIC_URL}/images/|" "$INDEX_JSON"
   sed -i "s|\"self\": \"/devfiles/|\"self\": \"${PUBLIC_URL}/devfiles/|" "$INDEX_JSON"
   sed -i "s|\"eclipse/che-theia/latest\": \"/devfiles/|\"eclipse/che-theia/latest\": \"${PUBLIC_URL}/devfiles/|" "$INDEX_JSON"
-  sed -i "s|\"eclipse/che-theia/next\": \"/devfiles/|\"eclipse/che-theia/next\": \"${PUBLIC_URL}/devfiles/|" "$INDEX_JSON"
   sed -i "s|\"che-incubator/che-code/insiders\": \"/devfiles/|\"che-incubator/che-code/insiders\": \"${PUBLIC_URL}/devfiles/|" "$INDEX_JSON"
 else
   if grep -q '{{ DEVFILE_REGISTRY_URL }}' "${devfiles[@]}"; then

--- a/build/scripts/generate_devworkspace_templates.sh
+++ b/build/scripts/generate_devworkspace_templates.sh
@@ -28,10 +28,6 @@ do
     name=$(basename "${devfile_repo}")
 
     npm_config_yes=true npx @eclipse-che/che-theia-devworkspace-handler@${CHE_THEIA_DEVWORKSPACE_HANDLER_VERSION} --devfile-url:"${devfile_url}" \
-    --output-file:"${dir}"/devworkspace-che-theia-next.yaml \
-    --project."${name}={{ INTERNAL_URL }}/resources/v2/${name}.zip"
-
-    npm_config_yes=true npx @eclipse-che/che-theia-devworkspace-handler@${CHE_THEIA_DEVWORKSPACE_HANDLER_VERSION} --devfile-url:"${devfile_url}" \
     --editor:eclipse/che-theia/latest \
     --output-file:"${dir}"/devworkspace-che-theia-latest.yaml \
     --project."${name}={{ INTERNAL_URL }}/resources/v2/${name}.zip"

--- a/build/scripts/index.sh
+++ b/build/scripts/index.sh
@@ -19,7 +19,6 @@ for meta in "${metas[@]}"; do
       # shellcheck disable=SC2016,SC2094
       cat <<< "$(yq -y --arg metadir "${META_DIR}" '.links.devWorkspaces |= . +
       {"eclipse/che-theia/latest": "/\($metadir)/devworkspace-che-theia-latest.yaml",
-      "eclipse/che-theia/next": "/\($metadir)/devworkspace-che-theia-next.yaml",
       "che-incubator/che-code/insiders": "/\($metadir)/devworkspace-che-code-insiders.yaml",}' "${meta}")" > "${meta}"
     fi
 done


### PR DESCRIPTION
### What does this PR do?

chore: theia/next is dead, remove it from devfile registry

Change-Id: I33288267d2b48afdd489dd88db9f75f67629372f
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

hopefully this fixes the problem here, trying to release 7.57:

```
#32 [linux/amd64 builder  8/11] RUN ./generate_devworkspace_templates.sh 7.57.0
#32 11.81 No plug-in registry url. Setting to https://eclipse-che.github.io/che-plugin-registry/main/v3
#32 11.82 No editor. Setting to eclipse/che-theia/next
#32 11.82 No sidecar policy. Setting to useDevContainer
#32 12.16 stack=Error: Request failed with status code 404
#32 12.16     at createError (/root/.npm/_npx/df22e5db283a47d7/node_modules/axios/lib/core/createError.js:16:15)
#32 12.16     at settle (/root/.npm/_npx/df22e5db283a47d7/node_modules/axios/lib/core/settle.js:17:12)
#32 12.16     at IncomingMessage.handleStreamEnd (/root/.npm/_npx/df22e5db283a47d7/node_modules/axios/lib/adapters/http.js:269:11)
#32 12.16     at IncomingMessage.emit (node:events:402:35)
#32 12.16     at endReadableNT (node:internal/streams/readable:1343:12)
#32 12.16     at processTicksAndRejections (node:internal/process/task_queues:83:21)
#32 12.17 Unable to start Error: Request failed with status code 404
#32 12.17     at createError (/root/.npm/_npx/df22e5db283a47d7/node_modules/axios/lib/core/createError.js:16:15)
#32 12.17     at settle (/root/.npm/_npx/df22e5db283a47d7/node_modules/axios/lib/core/settle.js:17:12)
#32 12.17     at IncomingMessage.handleStreamEnd (/root/.npm/_npx/df22e5db283a47d7/node_modules/axios/lib/adapters/http.js:269:11)
#32 12.17     at IncomingMessage.emit (node:events:402:35)
#32 12.17     at endReadableNT (node:internal/streams/readable:1343:12)
#32 12.17     at processTicksAndRejections (node:internal/process/task_queues:83:21) {
#32 12.17   config: {
#32 12.17     url: 'https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/eclipse/che-theia/next/devfile.yaml',
```
-- https://github.com/eclipse-che/che-devfile-registry/actions/runs/3532701492/jobs/5927382968


### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.