### PR TITLE
chore:add default dev container component

### DIFF
--- a/tools/devworkspace-generator/README.md
+++ b/tools/devworkspace-generator/README.md
@@ -23,6 +23,10 @@ OPTIONS
 
       --project.<project-name> local file path for the sample project zip (for airgapped/offline registry builds)
 
+      --injectDefaultComponent: inject a default dev container component if no component is defined in the devfile and it doesn't provide a parent, the value can be true or false, default is false
+
+      --defaultComponentImage: image to use for the default dev container component that will be injected if no componetn is defined in the devfile and it doesn't provide a parent devfile, default is quay.io/devfile/universal-developer-image:ubi8-latest
+
 EXAMPLES
 
     # online example, using editor definition from https://che-plugin-registry-main.surge.sh/
@@ -31,7 +35,9 @@ EXAMPLES
         --devfile-url:https://github.com/che-samples/java-spring-petclinic/tree/main \
         --plugin-registry-url:https://che-plugin-registry-main.surge.sh/v3/ \
         --editor-entry:che-incubator/che-code/latest \
-        --output-file:/tmp/devworkspace-che-code-latest.yaml`
+        --output-file:/tmp/devworkspace-che-code-latest.yaml \
+        --injectDefaultComponent:true \
+        --defaultComponentImage:registry.access.redhat.com/ubi8/openjdk-11:latest
 
     # offline example with devfile.yaml files and zipped project available locally
 

--- a/tools/devworkspace-generator/src/devfile/dev-container-component-inserter.ts
+++ b/tools/devworkspace-generator/src/devfile/dev-container-component-inserter.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { DevfileContext } from '../api/devfile-context';
+import { V1alpha2DevWorkspaceSpecTemplateComponents } from '@devfile/api';
+import { injectable } from 'inversify';
+
+/**
+ * Adds a new component on empty devfile with specific name and image
+ */
+@injectable()
+export class DevContainerComponentInserter {
+  readonly DEFAULT_DEV_CONTAINER_IMAGE = 'quay.io/devfile/universal-developer-image:ubi8-latest';
+  readonly DEFAULT_DEV_CONTAINER_NAME = 'dev';
+
+  async insert(devfileContext: DevfileContext, defaultComponentImage?: string): Promise<void> {
+    if (!devfileContext.devWorkspace.spec) {
+      devfileContext.devWorkspace.spec = {
+        started: true,
+      };
+    }
+    if (!devfileContext.devWorkspace.spec.template) {
+      devfileContext.devWorkspace.spec.template = {};
+    }
+    if (!devfileContext.devWorkspace.spec.template.components) {
+      devfileContext.devWorkspace.spec.template.components = [];
+    }
+
+    const devContainerImage = defaultComponentImage ? defaultComponentImage : this.DEFAULT_DEV_CONTAINER_IMAGE;
+    console.log(
+      `No container component has been found. A default container component with image ${devContainerImage} will be added.`
+    );
+    const devContainerComponent: V1alpha2DevWorkspaceSpecTemplateComponents = {
+      name: this.DEFAULT_DEV_CONTAINER_NAME,
+      container: {
+        image: devContainerImage,
+      },
+    };
+
+    devfileContext.devWorkspace.spec.template.components.push(devContainerComponent);
+  }
+}

--- a/tools/devworkspace-generator/src/devfile/devfile-module.ts
+++ b/tools/devworkspace-generator/src/devfile/devfile-module.ts
@@ -10,9 +10,11 @@
 import { ContainerModule, interfaces } from 'inversify';
 
 import { DevContainerComponentFinder } from './dev-container-component-finder';
+import { DevContainerComponentInserter } from './dev-container-component-inserter';
 
 const devfileModule = new ContainerModule((bind: interfaces.Bind) => {
   bind(DevContainerComponentFinder).toSelf().inSingletonScope();
+  bind(DevContainerComponentInserter).toSelf().inSingletonScope();
 });
 
 export { devfileModule };

--- a/tools/devworkspace-generator/src/generate.ts
+++ b/tools/devworkspace-generator/src/generate.ts
@@ -28,8 +28,19 @@ export class Generate {
   @inject(DevContainerComponentFinder)
   private devContainerComponentFinder: DevContainerComponentFinder;
 
-  async generate(devfileContent: string, editorContent: string, outputFile?: string): Promise<DevfileContext> {
-    const context = await this.generateContent(devfileContent, editorContent);
+  async generate(
+    devfileContent: string,
+    editorContent: string,
+    outputFile?: string,
+    injectDefaultComponent?: string,
+    defaultComponentImage?: string
+  ): Promise<DevfileContext> {
+    const context = await this.generateContent(
+      devfileContent,
+      editorContent,
+      injectDefaultComponent,
+      defaultComponentImage
+    );
 
     // write the result
     if (outputFile) {
@@ -46,7 +57,12 @@ export class Generate {
     return context;
   }
 
-  async generateContent(devfileContent: string, editorContent: string): Promise<DevfileContext> {
+  async generateContent(
+    devfileContent: string,
+    editorContent: string,
+    injectDefaultComponent?: string,
+    defaultComponentImage?: string
+  ): Promise<DevfileContext> {
     const devfile = jsYaml.load(devfileContent);
 
     // const originalDevfile = Object.assign({}, devfile);
@@ -102,7 +118,9 @@ export class Generate {
     };
 
     // grab container where to inject controller.devfile.io/merge-contribution attribute
-    let devContainer: V1alpha2DevWorkspaceSpecTemplateComponents = await this.devContainerComponentFinder.find(context);
+    let devContainer: V1alpha2DevWorkspaceSpecTemplateComponents | undefined =
+      await this.devContainerComponentFinder.find(context, injectDefaultComponent, defaultComponentImage);
+
     if (!devContainer) {
       return context;
     }

--- a/tools/devworkspace-generator/src/main.ts
+++ b/tools/devworkspace-generator/src/main.ts
@@ -38,6 +38,8 @@ export class Main {
       editorEntry?: string;
       pluginRegistryUrl?: string;
       projects: { name: string; location: string }[];
+      injectDefaultComponent?: string;
+      defaultComponentImage?: string;
     },
     axiosInstance: axios.AxiosInstance
   ): Promise<DevfileContext> {
@@ -112,7 +114,13 @@ export class Main {
     }
 
     const generate = container.get(Generate);
-    return generate.generate(devfileContent, editorContent, params.outputFile);
+    return generate.generate(
+      devfileContent,
+      editorContent,
+      params.outputFile,
+      params.injectDefaultComponent,
+      params.defaultComponentImage
+    );
   }
 
   // Update project entry based on the projects passed as parameter
@@ -149,6 +157,8 @@ export class Main {
     let editorPath: string | undefined;
     let pluginRegistryUrl: string | undefined;
     let editorEntry: string | undefined;
+    let injectDefaultComponent: string | undefined;
+    let defaultComponentImage: string | undefined;
     const projects: { name: string; location: string }[] = [];
 
     const args = process.argv.slice(2);
@@ -178,6 +188,12 @@ export class Main {
 
         projects.push({ name, location });
       }
+      if (arg.startsWith('--injectDefaultComponent:')) {
+        injectDefaultComponent = arg.substring('--injectDefaultComponent:'.length);
+      }
+      if (arg.startsWith('--defaultComponentImage:')) {
+        defaultComponentImage = arg.substring('--defaultComponentImage:'.length);
+      }
     });
 
     try {
@@ -199,6 +215,8 @@ export class Main {
           pluginRegistryUrl,
           editorEntry,
           projects,
+          injectDefaultComponent,
+          defaultComponentImage,
         },
         axios.default
       );

--- a/tools/devworkspace-generator/tests/devfile/dev-container-component-inserter.spec.ts
+++ b/tools/devworkspace-generator/tests/devfile/dev-container-component-inserter.spec.ts
@@ -1,0 +1,57 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { DevContainerComponentInserter } from '../../src/devfile/dev-container-component-inserter';
+import { DevfileContext } from '../../src/api/devfile-context';
+
+describe('Test DevContainerComponentInserter', () => {
+  let container: Container;
+
+  let devContainerComponentInserter: DevContainerComponentInserter;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(DevContainerComponentInserter).toSelf().inSingletonScope();
+    devContainerComponentInserter = container.get(DevContainerComponentInserter);
+  });
+
+  test('insert default component', async () => {
+    const devfileContext = {
+      devWorkspace: {},
+    } as DevfileContext;
+
+    const defaultImage = 'quay.io/devfile/universal-developer-image:ubi8-latest';
+
+    await devContainerComponentInserter.insert(devfileContext);
+    const devContainer = devfileContext.devWorkspace.spec?.template?.components?.[0];
+
+    expect(devfileContext.devWorkspace.spec?.template?.components?.length).toBe(1);
+    expect(devContainer?.name).toBe('dev');
+    expect(devContainer?.container?.image).toBe(defaultImage);
+  });
+
+  test('insert dev component with custom image', async () => {
+    const devfileContext = {
+      devWorkspace: {},
+    } as DevfileContext;
+
+    await devContainerComponentInserter.insert(devfileContext, 'my-image');
+    const devContainer = devfileContext.devWorkspace.spec?.template?.components?.[0];
+
+    expect(devfileContext.devWorkspace.spec?.template?.components?.length).toBe(1);
+    expect(devContainer?.name).toBe('dev');
+    expect(devContainer?.container?.image).toBe('my-image');
+  });
+});


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR provides an ability to inject a default dev container component into the DevWorkspace. For this, two additional parameters were added:
 
`--injectDefaultComponent:` inject a default dev container component if no component is defined in the devfile and it doesn't provide a parent, the value can be **true** or **false,** default is **false**

`--defaultComponentImage:` image to use for the dev container component that will be injected if injectDefaultComponent is true, default is **quay.io/devfile/universal-developer-image:ubi8-latest**

<details>
  <summary>The resulted DevWorkspace</summary>

```yaml
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspaceTemplate
metadata:
  name: che-code-empty
spec:
  commands:
    - id: init-container-command
      apply:
        component: che-code-injector
    - id: init-che-code-command
      exec:
        component: che-code-runtime-description
        commandLine: >-
          nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt
          2>&1 &
  events:
    preStart:
      - init-container-command
    postStart:
      - init-che-code-command
  components:
    - name: che-code-runtime-description
      container:
        image: >-
          quay.io/devfile/universal-developer-image@sha256:73d38afb1c7ce012d4c5f3b0c25894d2e70ae876effee6382e869d40d6ed468e
        volumeMounts:
          - name: checode
            path: /checode
        memoryLimit: 1024Mi
        memoryRequest: 256Mi
        cpuLimit: 500m
        cpuRequest: 30m
        endpoints:
          - name: che-code
            attributes:
              type: main
              cookiesAuthEnabled: true
              discoverable: false
              urlRewriteSupported: true
            targetPort: 3100
            exposure: public
            secure: false
            protocol: https
          - name: code-redirect-1
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13131
            exposure: public
            protocol: http
          - name: code-redirect-2
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13132
            exposure: public
            protocol: http
          - name: code-redirect-3
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13133
            exposure: public
            protocol: http
      attributes:
        app.kubernetes.io/component: che-code-runtime
        app.kubernetes.io/part-of: che-code.eclipse.org
        controller.devfile.io/container-contribution: true
    - name: checode
      volume: {}
    - name: che-code-injector
      container:
        image: >-
          quay.io/che-incubator/che-code@sha256:8fd9eca7c28c59ce93c0b24c7ff0f38080e9a2ac66668274aeabc6b8f3144012
        command:
          - /entrypoint-init-container.sh
        volumeMounts:
          - name: checode
            path: /checode
        memoryLimit: 256Mi
        memoryRequest: 32Mi
        cpuLimit: 500m
        cpuRequest: 30m
---
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: empty
spec:
  started: true
  routingClass: che
  template:
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:ubi8-latest
        attributes:
          controller.devfile.io/merge-contribution: true
  contributions:
    - name: editor
      kubernetes:
        name: che-code-empty
```
</details>

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![frame_safari_light](https://user-images.githubusercontent.com/1271546/232062428-228e0966-cc2d-4967-8fdb-e364fc00f0d5.png)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22082

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Try to generate a DevWorkspace using this devfile.yaml:
```yaml
schemaVersion: 2.1.0
metadata:
  name: empty
```
For this: 
- build `che-devfile-registry/tools/devworkspace-generator` by eecuting `yarn`
- create `devfile` folder in `che-devfile-registry/tools/devworkspace-generator`
- put devfile.yaml into `che-devfile-registry/tools/devworkspace-generator` folder
- execute a command that will generate a DevWorkspace:
```
node lib/entrypoint.js \
        --devfile-path:./devfile/devfile.yaml \
        --plugin-registry-url:https://che-plugin-registry-main.surge.sh/v3/ \
        --editor-entry:che-incubator/che-code/latest \
        --output-file:/tmp/all-in-one.yaml \
        --injectDefaultComponent:true \
        --defaultComponentImage:quay.io/devfile/universal-developer-image:latest
```
<details>
  <summary>The resulted file is</summary>

```yaml
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspaceTemplate
metadata:
  name: che-code-empty
spec:
  commands:
    - id: init-container-command
      apply:
        component: che-code-injector
    - id: init-che-code-command
      exec:
        component: che-code-runtime-description
        commandLine: >-
          nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt
          2>&1 &
  events:
    preStart:
      - init-container-command
    postStart:
      - init-che-code-command
  components:
    - name: che-code-runtime-description
      container:
        image: >-
          quay.io/devfile/universal-developer-image@sha256:73d38afb1c7ce012d4c5f3b0c25894d2e70ae876effee6382e869d40d6ed468e
        volumeMounts:
          - name: checode
            path: /checode
        memoryLimit: 1024Mi
        memoryRequest: 256Mi
        cpuLimit: 500m
        cpuRequest: 30m
        endpoints:
          - name: che-code
            attributes:
              type: main
              cookiesAuthEnabled: true
              discoverable: false
              urlRewriteSupported: true
            targetPort: 3100
            exposure: public
            secure: false
            protocol: https
          - name: code-redirect-1
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13131
            exposure: public
            protocol: http
          - name: code-redirect-2
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13132
            exposure: public
            protocol: http
          - name: code-redirect-3
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13133
            exposure: public
            protocol: http
      attributes:
        app.kubernetes.io/component: che-code-runtime
        app.kubernetes.io/part-of: che-code.eclipse.org
        controller.devfile.io/container-contribution: true
    - name: checode
      volume: {}
    - name: che-code-injector
      container:
        image: >-
          quay.io/che-incubator/che-code@sha256:8fd9eca7c28c59ce93c0b24c7ff0f38080e9a2ac66668274aeabc6b8f3144012
        command:
          - /entrypoint-init-container.sh
        volumeMounts:
          - name: checode
            path: /checode
        memoryLimit: 256Mi
        memoryRequest: 32Mi
        cpuLimit: 500m
        cpuRequest: 30m
---
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: empty
spec:
  started: true
  routingClass: che
  template:
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:latest
        attributes:
          controller.devfile.io/merge-contribution: true
  contributions:
    - name: editor
      kubernetes:
        name: che-code-empty
```
</details>

Now you can create a workspace via
`oc apply -f /tmp/all-in-one.yaml`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
