### PR TITLE
Ignore default components check when a devfile references a parent

### DIFF
--- a/tools/devworkspace-generator/src/devfile/dev-container-component-finder.ts
+++ b/tools/devworkspace-generator/src/devfile/dev-container-component-finder.ts
@@ -26,7 +26,6 @@ export class DevContainerComponentFinder {
         component => component.container && component.container.mountSources !== false
       );
 
-    // only one, fine, else error
     if (!devComponents || devComponents.length === 0) {
       if (devfileContext.devfile.parent) {
         return undefined;

--- a/tools/devworkspace-generator/src/devfile/dev-container-component-finder.ts
+++ b/tools/devworkspace-generator/src/devfile/dev-container-component-finder.ts
@@ -28,6 +28,9 @@ export class DevContainerComponentFinder {
 
     // only one, fine, else error
     if (!devComponents || devComponents.length === 0) {
+      if (devfileContext.devfile.parent) {
+        return undefined;
+      }
       throw new Error('Not able to find any dev container component in DevWorkspace');
     } else if (devComponents.length === 1) {
       return devComponents[0];

--- a/tools/devworkspace-generator/src/generate.ts
+++ b/tools/devworkspace-generator/src/generate.ts
@@ -103,6 +103,9 @@ export class Generate {
 
     // grab container where to inject controller.devfile.io/merge-contribution attribute
     let devContainer: V1alpha2DevWorkspaceSpecTemplateComponents = await this.devContainerComponentFinder.find(context);
+    if (!devContainer) {
+      return context;
+    }
 
     // add attributes
     let devContainerAttributes = devContainer.attributes;

--- a/tools/devworkspace-generator/tests/devfile/dev-container-component-finder.spec.ts
+++ b/tools/devworkspace-generator/tests/devfile/dev-container-component-finder.spec.ts
@@ -87,8 +87,9 @@ describe('Test DevContainerComponentFinder', () => {
     expect(devWorkspaceSpecTemplateComponents.name).toBe('my-container');
   });
 
-  test('missing dev container', async () => {
+  test('missing dev container without devfile.parent', async () => {
     const devfileContext = {
+      devfile: {},
       devWorkspace: {
         spec: {
           template: {
@@ -107,8 +108,35 @@ describe('Test DevContainerComponentFinder', () => {
     );
   });
 
+  test('missing dev container with devfile.parent', async () => {
+    const devfileContext = {
+      devfile: {
+        parent: {
+          id: 'java-maven',
+          registryUrl: 'https://registry.stage.devfile.io/',
+          version: '1.2.0',
+        },
+      },
+      devWorkspace: {
+        spec: {
+          template: {
+            components: [
+              { name: 'foo' },
+              {
+                name: 'che-code',
+              },
+            ],
+          },
+        },
+      },
+    } as DevfileContext;
+    const devWorkspaceSpecTemplateComponents = await devContainerComponentFinder.find(devfileContext);
+    expect(devWorkspaceSpecTemplateComponents).toBeUndefined();
+  });
+
   test('missing dev container (no components)', async () => {
     const devfileContext = {
+      devfile: {},
       devWorkspace: {},
     } as DevfileContext;
     await expect(devContainerComponentFinder.find(devfileContext)).rejects.toThrow(


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Ignore default components check when a devfile references a parent.



### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
It needs for https://github.com/eclipse/che/issues/22103

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Create a new workspace from https://gist.githubusercontent.com/olexii4/fc3b757806e660dee0fbe1bc131df3d1/raw/1212b86a69440a30d3d06cbe412c72bbbb665daf/empty.yaml

```
schemaVersion: 2.2.0
metadata:
  generateName: empty
parent:
  id: udi
  registryUrl: https://registry.stage.devfile.io/
  version: 1.0.0
```

![Знімок екрана 2023-04-18 о 16 15 30](https://user-images.githubusercontent.com/6310786/232789081-fdf4aa0f-fcfa-4ac5-b9a5-314a1ac82309.png)
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
