### PR TITLE
chore: add routingClass:che into generated DevWorkspace

### DIFF
--- a/tools/devworkspace-generator/src/generate.ts
+++ b/tools/devworkspace-generator/src/generate.ts
@@ -102,6 +102,7 @@ export class Generate {
       metadata: devfileMetadata,
       spec: {
         started: true,
+        routingClass: 'che',
         template: devfileCopy,
         contributions: [editorSpecContribution],
       },

--- a/tools/devworkspace-generator/tests/generate.spec.ts
+++ b/tools/devworkspace-generator/tests/generate.spec.ts
@@ -63,6 +63,7 @@ metadata:
         metadata: { name: 'my-dummy-project' },
         spec: {
           started: true,
+          routingClass: 'che',
           template: {
             parent: {
               id: 'udi',
@@ -122,6 +123,7 @@ metadata:
         metadata: { name: 'my-dummy-project' },
         spec: {
           started: true,
+          routingClass: 'che',
           template: {
             components: [
               {
@@ -189,6 +191,7 @@ metadata:
         metadata: { name: 'my-dummy-project' },
         spec: {
           started: true,
+          routingClass: 'che',
           template: {
             components: [
               {
@@ -256,6 +259,7 @@ metadata:
         metadata: { name: 'my-dummy-project' },
         spec: {
           started: true,
+          routingClass: 'che',
           template: {
             components: [
               {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Overrides a default `routingClass` by setting `routingClass: che` in a generated DevWorkspace:
```yaml
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: spring-petclinic
spec:
  started: true
  routingClass: che
```
 
<details>
  <summary>An example of the generated DevWorkspace</summary>

```yaml
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspaceTemplate
metadata:
  name: che-code-inventory-quarkus
spec:
  commands:
    - id: init-container-command
      apply:
        component: che-code-injector
    - id: init-che-code-command
      exec:
        component: che-code-runtime-description
        commandLine: >-
          nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt
          2>&1 &
  events:
    preStart:
      - init-container-command
    postStart:
      - init-che-code-command
  components:
    - name: che-code-runtime-description
      container:
        image: >-
          quay.io/devfile/universal-developer-image@sha256:d4434a3944861c7a4de4570b1f56b3014c4ab1de05f5a9cf59d30d5fa4fc7154
        volumeMounts:
          - name: checode
            path: /checode
        memoryLimit: 1024Mi
        memoryRequest: 256Mi
        cpuLimit: 500m
        cpuRequest: 30m
        endpoints:
          - name: che-code
            attributes:
              type: main
              cookiesAuthEnabled: true
              discoverable: false
              urlRewriteSupported: true
            targetPort: 3100
            exposure: public
            secure: false
            protocol: https
          - name: code-redirect-1
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13131
            exposure: public
            protocol: http
          - name: code-redirect-2
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13132
            exposure: public
            protocol: http
          - name: code-redirect-3
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13133
            exposure: public
            protocol: http
      attributes:
        app.kubernetes.io/component: che-code-runtime
        app.kubernetes.io/part-of: che-code.eclipse.org
        controller.devfile.io/container-contribution: true
    - name: checode
      volume: {}
    - name: che-code-injector
      container:
        image: >-
          quay.io/che-incubator/che-code@sha256:bdf11726e63451290781fd4f03dfb19fa09b6c3a7cefdca77b5014139cefa16b
        command:
          - /entrypoint-init-container.sh
        volumeMounts:
          - name: checode
            path: /checode
        memoryLimit: 256Mi
        memoryRequest: 32Mi
        cpuLimit: 500m
        cpuRequest: 30m
---
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: inventory-quarkus
spec:
  started: true
  routingClass: che
  template:
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:ubi8-latest
        attributes:
          controller.devfile.io/merge-contribution: true
  contributions:
    - name: editor
      kubernetes:
        name: che-code-inventory-quarkus

```
</details>

### Screenshot/screencast of this PR
![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 04 21-14_57_39](https://user-images.githubusercontent.com/1271546/233630820-3c6d5624-698a-4ece-84ca-0530642bd648.png)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22149

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Try to generate a DevWorkspace using this devfile.yaml:
```yaml
schemaVersion: 2.2.0
metadata:
  name: inventory-quarkus
```
For this: 
- build `che-devfile-registry/tools/devworkspace-generator` by executing `yarn`
- create `devfile` folder in `che-devfile-registry/tools/devworkspace-generator`
- put devfile.yaml into `che-devfile-registry/tools/devworkspace-generator` folder
- execute a command that will generate a DevWorkspace:
```
node lib/entrypoint.js \       
        --devfile-path:./devfile/devfile.yaml \
        --plugin-registry-url:https://che-plugin-registry-main.surge.sh/v3/ \
        --editor-entry:che-incubator/che-code/latest \
        --output-file:/tmp/all-in-one.yaml \
        --injectDefaultComponent:true
```
<details>
  <summary>The resulted file is</summary>

```yaml
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspaceTemplate
metadata:
  name: che-code-inventory-quarkus
spec:
  commands:
    - id: init-container-command
      apply:
        component: che-code-injector
    - id: init-che-code-command
      exec:
        component: che-code-runtime-description
        commandLine: >-
          nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt
          2>&1 &
  events:
    preStart:
      - init-container-command
    postStart:
      - init-che-code-command
  components:
    - name: che-code-runtime-description
      container:
        image: >-
          quay.io/devfile/universal-developer-image@sha256:d4434a3944861c7a4de4570b1f56b3014c4ab1de05f5a9cf59d30d5fa4fc7154
        volumeMounts:
          - name: checode
            path: /checode
        memoryLimit: 1024Mi
        memoryRequest: 256Mi
        cpuLimit: 500m
        cpuRequest: 30m
        endpoints:
          - name: che-code
            attributes:
              type: main
              cookiesAuthEnabled: true
              discoverable: false
              urlRewriteSupported: true
            targetPort: 3100
            exposure: public
            secure: false
            protocol: https
          - name: code-redirect-1
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13131
            exposure: public
            protocol: http
          - name: code-redirect-2
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13132
            exposure: public
            protocol: http
          - name: code-redirect-3
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13133
            exposure: public
            protocol: http
      attributes:
        app.kubernetes.io/component: che-code-runtime
        app.kubernetes.io/part-of: che-code.eclipse.org
        controller.devfile.io/container-contribution: true
    - name: checode
      volume: {}
    - name: che-code-injector
      container:
        image: >-
          quay.io/che-incubator/che-code@sha256:bdf11726e63451290781fd4f03dfb19fa09b6c3a7cefdca77b5014139cefa16b
        command:
          - /entrypoint-init-container.sh
        volumeMounts:
          - name: checode
            path: /checode
        memoryLimit: 256Mi
        memoryRequest: 32Mi
        cpuLimit: 500m
        cpuRequest: 30m
---
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: inventory-quarkus
spec:
  started: true
  routingClass: che
  template:
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:ubi8-latest
        attributes:
          controller.devfile.io/merge-contribution: true
  contributions:
    - name: editor
      kubernetes:
        name: che-code-inventory-quarkus

```
</details>

Now you can create a workspace via
`oc apply -f /tmp/all-in-one.yaml`

The workspace should start and it should be possible to open the IDE with che-code editor

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
