### PR TITLE
feat: Add devworkspace-generator to Che release cycle

### DIFF
--- a/.github/workflows/devworkspace-generator-release.yml
+++ b/.github/workflows/devworkspace-generator-release.yml
@@ -67,17 +67,18 @@ jobs:
           yarn
           yarn compile
           npm publish --tag latest
-      - name: Create failure MM message
-        if: ${{ failure() }}
-        run: |
-          echo "{\"text\":\":no_entry_sign: Che Devworkspace Generator ${{ github.event.inputs.version }} release has failed: https://github.com/eclipse-che/che-devfile-registry/actions/workflows/release.yml\"}" > mattermost.json
-      - name: Create success MM message
-        run: |
-          echo "{\"text\":\":white_check_mark: Che Devworkspace Generator ${{ github.event.inputs.version }} has been released: https://www.npmjs.com/package/@eclipse-che/che-devworkspace-generator/v/${{ github.event.inputs.version }}\"}" > mattermost.json
-      - name: Send MM message
-        if: ${{ success() }} || ${{ failure() }}
-        uses: mattermost/action-mattermost-notify@1.1.0
-        env:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-          MATTERMOST_CHANNEL: eclipse-che-releases
-          MATTERMOST_USERNAME: che-bot
+    # che-22407 - mattermost steps are commented out, until we find a replacement for it
+    #  - name: Create failure MM message
+    #     if: ${{ failure() }}
+    #     run: |
+    #       echo "{\"text\":\":no_entry_sign: Che Devworkspace Generator ${{ github.event.inputs.version }} release has failed: https://github.com/eclipse-che/che-devfile-registry/actions/workflows/release.yml\"}" > mattermost.json
+    #   - name: Create success MM message
+    #     run: |
+    #       echo "{\"text\":\":white_check_mark: Che Devworkspace Generator ${{ github.event.inputs.version }} has been released: https://www.npmjs.com/package/@eclipse-che/che-devworkspace-generator/v/${{ github.event.inputs.version }}\"}" > mattermost.json
+    #   - name: Send MM message
+    #     if: ${{ success() }} || ${{ failure() }}
+    #     uses: mattermost/action-mattermost-notify@1.1.0
+    #     env:
+    #       MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+    #       MATTERMOST_CHANNEL: eclipse-che-releases
+    #       MATTERMOST_USERNAME: che-bot

--- a/.github/workflows/devworkspace-generator-release.yml
+++ b/.github/workflows/devworkspace-generator-release.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021 Red Hat, Inc.
+# Copyright (c) 2023 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/devworkspace-generator-release.yml
+++ b/.github/workflows/devworkspace-generator-release.yml
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2020-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: Release Che Devworkspace Generator
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'release version in format 7.y.z'
+        required: true
+      forceRecreateTags:
+        description: If true, tags will be recreated. Use with caution
+        required: false
+        default: 'false'
+
+jobs:
+  build:
+    name: Create Che Devfile Registry Release
+    runs-on: ubuntu-22.04
+    steps:
+      -
+        name: "Checkout source code"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - 
+        name: Check existing tags
+        if: github.event.inputs.performRelease == 'true'
+        run: |
+          set +e
+          RECREATE_TAGS=${{ github.event.inputs.forceRecreateTags }}
+          VERSION=${{ github.event.inputs.version }}
+          EXISTING_TAG=$(git ls-remote --exit-code origin refs/tags/${VERSION})
+          if [[ -n ${EXISTING_TAG} ]]; then
+            if [[ ${RECREATE_TAGS} == "true" ]]; then
+              echo "[INFO] Removing tag for ${VERSION} version. New tag will be recreated during release."
+              git push origin :$VERSION
+            else
+              echo "[ERROR] Cannot proceed with release - tag ${EXISTING_TAG} already exists."
+              exit 1
+            fi
+          else
+            echo "[INFO] No existing tags detected for $VERSION"
+          fi
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-${{ hashFiles('tools/devworkspace-generator/yarn.lock') }}
+        restore-keys: yarn-
+      - name: publish DevWorkspace Generator
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: |
+          cd tools/devworkspace-generator
+          sed -i -r -e "s/(\"version\": )(\".*\")/\1\"${thisVERSION}\"/" package.json
+          yarn
+          yarn compile
+          npm publish --tag latest
+      - name: Create failure MM message
+        if: ${{ failure() }}
+        run: |
+          echo "{\"text\":\":no_entry_sign: Che Devworkspace Generator ${{ github.event.inputs.version }} release has failed: https://github.com/eclipse-che/che-devfile-registry/actions/workflows/release.yml\"}" > mattermost.json
+      - name: Create success MM message
+        run: |
+          echo "{\"text\":\":white_check_mark: Che Devworkspace Generator ${{ github.event.inputs.version }} has been released: https://www.npmjs.com/package/@eclipse-che/che-devworkspace-generator/v/${{ github.event.inputs.version }}\"}" > mattermost.json
+      - name: Send MM message
+        if: ${{ success() }} || ${{ failure() }}
+        uses: mattermost/action-mattermost-notify@1.1.0
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          MATTERMOST_CHANNEL: eclipse-che-releases
+          MATTERMOST_USERNAME: che-bot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021 Red Hat, Inc.
+# Copyright (c) 2020-2023 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -91,8 +91,8 @@ jobs:
 
           export GITHUB_TOKEN=${{ secrets.CHE_BOT_GITHUB_TOKEN }}
           ./make-release.sh --version ${{ github.event.inputs.version}} --trigger-release
-
-      - name: Generate devfiles with registryUrls and publish to GH pages
+      - 
+        name: Generate devfiles with registryUrls and publish to GH pages
         if: github.event.inputs.publishDevfilesToGhPages == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.CHE_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,15 +57,6 @@ jobs:
           else
             echo "[INFO] No existing tags detected for $VERSION"
           fi
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-${{ hashFiles('tools/devworkspace-generator/yarn.lock') }}
-        restore-keys: yarn-
       -
         name: "Set up QEMU"
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,15 @@ jobs:
           else
             echo "[INFO] No existing tags detected for $VERSION"
           fi
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-${{ hashFiles('tools/devworkspace-generator/yarn.lock') }}
+        restore-keys: yarn-
       -
         name: "Set up QEMU"
         uses: docker/setup-qemu-action@v2

--- a/make-release.sh
+++ b/make-release.sh
@@ -166,11 +166,11 @@ fetchAndCheckout ()
   git fetch origin "${bBRANCH}:${bBRANCH}"; git checkout "${bBRANCH}"
 }
 
-# unlike in che-plugin-registry, here we just need to update the VERSION file
 updateVersion () {
   thisVERSION="$1"
   # update VERSION file with VERSION or NEWVERSION
   echo "${thisVERSION}" > VERSION
+  # ensure version of devworkspace-generator is updated
   sed -i -r -e "s/(\"version\": )(\".*\")/\1\"${thisVERSION}\"/" tools/devworkspace-generator/package.json
 }
 
@@ -242,6 +242,8 @@ commitChangeOrCreatePR()
 
 # bump VERSION file to VERSION
 updateVersion "${VERSION}"
+# use release version for devworkspace generator
+sed -i -r -e "s/CHE_DEVWORKSPACE_GENERATOR_VERSION=next/CHE_DEVWORKSPACE_GENERATOR_VERSION=${VERSION}/" build/scripts/generate_devworkspace_templates.sh
 
 # commit change into branch
 commitChangeOrCreatePR "${VERSION}" "${BRANCH}" "pr-${BRANCH}-to-${VERSION}"

--- a/make-release.sh
+++ b/make-release.sh
@@ -167,10 +167,11 @@ fetchAndCheckout ()
 }
 
 # unlike in che-plugin-registry, here we just need to update the VERSION file
-updateVersionFile () {
+updateVersion () {
   thisVERSION="$1"
   # update VERSION file with VERSION or NEWVERSION
   echo "${thisVERSION}" > VERSION
+  sed -i -r -e "s/(\"version\": )(\".*\")/\1\"${thisVERSION}\"/" tools/devworkspace-generator/package.json
 }
 
 if [[ ! ${VERSION} ]]; then
@@ -240,7 +241,7 @@ commitChangeOrCreatePR()
 }
 
 # bump VERSION file to VERSION
-updateVersionFile "${VERSION}"
+updateVersion "${VERSION}"
 
 # commit change into branch
 commitChangeOrCreatePR "${VERSION}" "${BRANCH}" "pr-${BRANCH}-to-${VERSION}"
@@ -271,7 +272,7 @@ else
 fi
 
 # bump VERSION file to NEXTVERSION
-updateVersionFile "${NEXTVERSION}"
+updateVersion "${NEXTVERSION}"
 commitChangeOrCreatePR "${NEXTVERSION}" "${BASEBRANCH}" "pr-${BASEBRANCH}-to-${NEXTVERSION}"
 
 # cleanup tmp dir

--- a/make-release.sh
+++ b/make-release.sh
@@ -242,7 +242,7 @@ commitChangeOrCreatePR()
 
 # bump VERSION file to VERSION
 updateVersion "${VERSION}"
-# use release version for devworkspace generator
+# update build scripts to reference release version of devworkspace generator
 sed -i -r -e "s/CHE_DEVWORKSPACE_GENERATOR_VERSION=next/CHE_DEVWORKSPACE_GENERATOR_VERSION=${VERSION}/" build/scripts/generate_devworkspace_templates.sh
 
 # commit change into branch

--- a/make-release.sh
+++ b/make-release.sh
@@ -170,10 +170,9 @@ updateVersion () {
   thisVERSION="$1"
   # update main VERSION file of devfile registry
   echo "${thisVERSION}" > VERSION
-  # update version of devworkspace-generator
+  # update version of devworkspace-generator in package.json
   jq ".\"dependencies\".\"@eclipse-che/che-devworkspace-generator\" = \"${thisVERSION}\"" tools/devworkspace-generator/package.json > tools/devworkspace-generator/package.json.update
   mv tools/devworkspace-generator/package.json.update tools/devworkspace-generator/package.json
-  sed -i -r -e "s/(\"version\": )(\".*\")/\1\"${thisVERSION}\"/" tools/devworkspace-generator/package.json
 }
 
 if [[ ! ${VERSION} ]]; then

--- a/make-release.sh
+++ b/make-release.sh
@@ -168,9 +168,11 @@ fetchAndCheckout ()
 
 updateVersion () {
   thisVERSION="$1"
-  # update VERSION file with VERSION or NEWVERSION
+  # update main VERSION file of devfile registry
   echo "${thisVERSION}" > VERSION
-  # ensure version of devworkspace-generator is updated
+  # update version of devworkspace-generator
+  jq ".\"dependencies\".\"@eclipse-che/che-devworkspace-generator\" = \"${thisVERSION}\"" tools/devworkspace-generator/package.json > tools/devworkspace-generator/package.json.update
+  mv tools/devworkspace-generator/package.json.update tools/devworkspace-generator/package.json
   sed -i -r -e "s/(\"version\": )(\".*\")/\1\"${thisVERSION}\"/" tools/devworkspace-generator/package.json
 }
 

--- a/tools/devworkspace-generator/package.json
+++ b/tools/devworkspace-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-che/che-devworkspace-generator",
-  "version": "0.0.1",
+  "version": "7.69.0",
   "private": false,
   "description": "Generates DevWorkspaces by transforming existing devfiles",
   "main": "lib/entrypoint.js",


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Che Devworkspace Generator (here Generator) shall be assigned a che version pattern, so that a che-version artifact will be produced on release (to be used in other che projects, that depend on it).
In main branch, current 0.0.1 version will be changed to next "would-be-released" version, similarly to how it is done in plugin registry.

UPDATE:

Created a separate workflow for releasing just the Generator, which could be performed in the first phase of Che release cycle, so that the projects that depend on it could be released in the following phases ASAP. Release tagging of repo will occur in Devfile Registry release workflow


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22279

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
