### PR TITLE
Add Bitbucket and Bitbucket Server support

### DIFF
--- a/build/scripts/generate_devworkspace_templates.sh
+++ b/build/scripts/generate_devworkspace_templates.sh
@@ -18,6 +18,7 @@ do
   if [ -n "$devfile_url" ]; then
     devfile_url=${devfile_url##*v2: }
     devfile_url=${devfile_url%/}
+    #generate a temporary devworkspace yaml to fetch git repository name and clone url.
     npm_config_yes=true npx @eclipse-che/che-devworkspace-generator@${CHE_DEVWORKSPACE_GENERATOR_VERSION} \
         --devfile-url:"${devfile_url}" \
         --editor-entry:che-incubator/che-code/latest \

--- a/build/scripts/generate_devworkspace_templates.sh
+++ b/build/scripts/generate_devworkspace_templates.sh
@@ -18,8 +18,11 @@ do
   if [ -n "$devfile_url" ]; then
     devfile_url=${devfile_url##*v2: }
     devfile_url=${devfile_url%/}
-    devfile_repo=${devfile_url%/tree*}
-    name=$(basename "${devfile_repo}")
+    npm_config_yes=true npx @eclipse-che/che-devworkspace-generator@${CHE_DEVWORKSPACE_GENERATOR_VERSION} \
+        --devfile-url:"${devfile_url}" \
+        --editor-entry:che-incubator/che-code/latest \
+        --output-file:"${dir}"temp.yaml
+    name=$(yq -r '.spec.template.projects[0].name' "${dir}temp.yaml"  | sed -n '2 p')
     project="${name}={{_INTERNAL_URL_}}/resources/v2/${name}.zip"
 
     npm_config_yes=true npx @eclipse-che/che-devworkspace-generator@${CHE_DEVWORKSPACE_GENERATOR_VERSION} \

--- a/build/scripts/update_devworkspace_templates.sh
+++ b/build/scripts/update_devworkspace_templates.sh
@@ -18,11 +18,9 @@ source ./clone_and_zip.sh
 mkdir -p /build/resources/v2/
 for dir in /build/devfiles/*/
 do
-    devfile_url=$(grep "v2:" "${dir}"meta.yaml) || :
-        if [ -n "$devfile_url" ]; then
-            clone_url=$(yq -r '.spec.template.projects[0].git.remotes.origin' "${dir}temp.yaml"  | sed -n '2 p')
-            revision=$(yq -r '.spec.template.projects[0].git.checkoutFrom.revision' "${dir}temp.yaml"  | sed -n '2 p')
-            name=$(yq -r '.spec.template.projects[0].name' "${dir}temp.yaml"  | sed -n '2 p')
-            clone_and_zip "${clone_url}" "${revision}" "/build/resources/v2/$name.zip"
-        fi
+    clone_url=$(yq -r '.spec.template.projects[0].git.remotes.origin' "${dir}temp.yaml"  | sed -n '2 p')
+    revision=$(yq -r '.spec.template.projects[0].git.checkoutFrom.revision' "${dir}temp.yaml"  | sed -n '2 p')
+    name=$(yq -r '.spec.template.projects[0].name' "${dir}temp.yaml"  | sed -n '2 p')
+    clone_and_zip "${clone_url}" "${revision}" "/build/resources/v2/$name.zip"
+    rm "${dir}temp.yaml"
 done

--- a/build/scripts/update_devworkspace_templates.sh
+++ b/build/scripts/update_devworkspace_templates.sh
@@ -20,10 +20,9 @@ for dir in /build/devfiles/*/
 do
     devfile_url=$(grep "v2:" "${dir}"meta.yaml) || :
         if [ -n "$devfile_url" ]; then
-            devfile_url=${devfile_url##*v2: }
-            devfile_url=${devfile_url%/}
-            devfile_repo=${devfile_url%/tree*}
-            name=$(basename "${devfile_repo}")
-            clone_and_zip "${devfile_repo}" "${devfile_url##*/}" "/build/resources/v2/$name.zip"
+            clone_url=$(yq -r '.spec.template.projects[0].git.remotes.origin' "${dir}temp.yaml"  | sed -n '2 p')
+            revision=$(yq -r '.spec.template.projects[0].git.checkoutFrom.revision' "${dir}temp.yaml"  | sed -n '2 p')
+            name=$(yq -r '.spec.template.projects[0].name' "${dir}temp.yaml"  | sed -n '2 p')
+            clone_and_zip "${clone_url}" "${revision}" "/build/resources/v2/$name.zip"
         fi
 done

--- a/tools/devworkspace-generator/src/bitbucket-server/bitbucket-server-module.ts
+++ b/tools/devworkspace-generator/src/bitbucket-server/bitbucket-server-module.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2023 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,13 +9,13 @@
  ***********************************************************************/
 import { ContainerModule, interfaces } from 'inversify';
 
-import { GithubResolver } from './github-resolver';
+import { BitbucketServerResolver } from './bitbucket-server-resolver';
 import { TYPES } from '../types';
 
 const { Resolver } = TYPES;
 
-const githubModule = new ContainerModule((bind: interfaces.Bind) => {
-  bind(Resolver).to(GithubResolver).inSingletonScope();
+const bitbucketServerModule = new ContainerModule((bind: interfaces.Bind) => {
+  bind(Resolver).to(BitbucketServerResolver).inSingletonScope();
 });
 
-export { githubModule };
+export { bitbucketServerModule };

--- a/tools/devworkspace-generator/src/bitbucket-server/bitbucket-server-resolver.ts
+++ b/tools/devworkspace-generator/src/bitbucket-server/bitbucket-server-resolver.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { BitbucketServerUrl } from './bitbucket-server-url';
+import { injectable } from 'inversify';
+import { Url } from '../resolve/url';
+import { Resolver } from '../resolve/resolver';
+
+@injectable()
+export class BitbucketServerResolver implements Resolver {
+  // eslint-disable-next-line max-len
+  static readonly BITBUCKET_URL_PATTERNS: RegExp[] = [
+    /^(?<scheme>https?):\/\/(?<host>.*)\/scm\/~(?<user>[^\/]+)\/(?<repo>.*).git$/,
+    /^(?<scheme>https?):\/\/(?<host>.*)\/users\/(?<user>[^\/]+)\/repos\/(?<repo>[^\/]+)\/browse(\?at=(?<branch>.*))?$/,
+    /^(?<scheme>https?):\/\/(?<host>.*)\/scm\/(?<project>[^\/~]+)\/(?<repo>[^\/]+).git$/,
+    /^(?<scheme>https?):\/\/(?<host>.*)\/projects\/(?<project>[^\/]+)\/repos\/(?<repo>[^\/]+)\/browse(\?at=(?<branch>.*))?$/,
+  ];
+
+  isValid(url: string): boolean {
+    return BitbucketServerResolver.BITBUCKET_URL_PATTERNS.some(p => p.test(url));
+  }
+
+  resolve(url: string): Url {
+    const regExp = BitbucketServerResolver.BITBUCKET_URL_PATTERNS.find(p => p.test(url));
+    if (!regExp) {
+      throw new Error(`Invalid bitbucket-server URL: ${url}`);
+    }
+    const match = regExp.exec(url);
+    const scheme = this.getGroup(match, 'scheme');
+    const hostName = this.getGroup(match, 'host');
+    const user = this.getGroup(match, 'user');
+    const project = this.getGroup(match, 'project');
+    const repo = this.getGroup(match, 'repo');
+    let branch = this.getGroup(match, 'branch');
+    if (branch !== undefined && branch.startsWith('refs%2Fheads%2F')) {
+      branch = branch.substring(15);
+    }
+    return new BitbucketServerUrl(scheme, hostName, user, project, repo, branch);
+  }
+
+  private getGroup(match: RegExpExecArray, groupName: string): string | undefined {
+    if (match.groups && match.groups[groupName]) {
+      return match.groups[groupName];
+    }
+  }
+}

--- a/tools/devworkspace-generator/src/bitbucket-server/bitbucket-server-url.ts
+++ b/tools/devworkspace-generator/src/bitbucket-server/bitbucket-server-url.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { Url } from '../resolve/url';
+
+export class BitbucketServerUrl implements Url {
+  constructor(
+    private readonly scheme: string,
+    private readonly hostName: string,
+    private readonly user: string | undefined,
+    private readonly project: string | undefined,
+    private readonly repo: string,
+    private readonly branch: string | undefined
+  ) {}
+
+  getContentUrl(path: string): string {
+    const isUser = this.user !== undefined;
+    return `${this.scheme}://${this.hostName}/${isUser ? 'users' : 'projects'}/${
+      isUser ? this.user : this.project
+    }/repos/${this.repo}/raw/${path}${this.branch !== undefined ? '?/at=' + this.branch : ''}`;
+  }
+
+  getUrl(): string {
+    const isUser = this.user !== undefined;
+    return `${this.scheme}://${this.hostName}/${isUser ? 'users' : 'projects'}/${
+      isUser ? this.user : this.project
+    }/repos/${this.repo}${this.branch !== undefined ? '/browse?at=' + this.branch : ''}`;
+  }
+
+  getCloneUrl(): string {
+    const isUser = this.user !== undefined;
+    return `${this.scheme}://${this.hostName}/scm/${isUser ? '~' + this.user : this.project.toLowerCase()}/${
+      this.repo
+    }.git`;
+  }
+
+  getRepoName(): string {
+    return this.repo;
+  }
+
+  getBranchName(): string {
+    return this.branch;
+  }
+}

--- a/tools/devworkspace-generator/src/bitbucket/bitbucket-module.ts
+++ b/tools/devworkspace-generator/src/bitbucket/bitbucket-module.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2023 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,13 +9,13 @@
  ***********************************************************************/
 import { ContainerModule, interfaces } from 'inversify';
 
-import { GithubResolver } from './github-resolver';
+import { BitbucketResolver } from './bitbucket-resolver';
 import { TYPES } from '../types';
 
 const { Resolver } = TYPES;
 
-const githubModule = new ContainerModule((bind: interfaces.Bind) => {
-  bind(Resolver).to(GithubResolver).inSingletonScope();
+const bitbucketModule = new ContainerModule((bind: interfaces.Bind) => {
+  bind(Resolver).to(BitbucketResolver).inSingletonScope();
 });
 
-export { githubModule };
+export { bitbucketModule };

--- a/tools/devworkspace-generator/src/bitbucket/bitbucket-resolver.ts
+++ b/tools/devworkspace-generator/src/bitbucket/bitbucket-resolver.ts
@@ -41,6 +41,6 @@ export class BitbucketResolver implements Resolver {
     if (match.groups && match.groups[groupName]) {
       return match.groups[groupName];
     }
-    return defaultValue || '';
+    return defaultValue;
   }
 }

--- a/tools/devworkspace-generator/src/bitbucket/bitbucket-url.ts
+++ b/tools/devworkspace-generator/src/bitbucket/bitbucket-url.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { Url } from '../resolve/url';
+
+export class BitbucketUrl implements Url {
+  private static readonly BITBUCKET_URL = 'https://bitbucket.org';
+
+  constructor(
+    private readonly workspaceId: string,
+    private readonly repoName: string,
+    private readonly branchName: string
+  ) {}
+
+  getContentUrl(path: string): string {
+    return `${BitbucketUrl.BITBUCKET_URL}/${this.workspaceId}/${this.repoName}/raw/${this.branchName}/${path}`;
+  }
+
+  getUrl(): string {
+    return `${BitbucketUrl.BITBUCKET_URL}/${this.workspaceId}/${this.repoName}/src/${this.branchName}`;
+  }
+
+  getCloneUrl(): string {
+    return `${BitbucketUrl.BITBUCKET_URL}/${this.workspaceId}/${this.repoName}.git`;
+  }
+
+  getRepoName(): string {
+    return this.repoName;
+  }
+
+  getBranchName(): string {
+    return this.branchName;
+  }
+}

--- a/tools/devworkspace-generator/src/github/github-url.ts
+++ b/tools/devworkspace-generator/src/github/github-url.ts
@@ -8,10 +8,9 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-/**
- * Provides helper methods on top of github URL to get for example raw content of get relative links
- */
-export class GithubUrl {
+import { Url } from '../resolve/url';
+
+export class GithubUrl implements Url {
   constructor(
     private readonly scheme: string,
     private readonly hostName: string,

--- a/tools/devworkspace-generator/src/inversify/inversify-binding.ts
+++ b/tools/devworkspace-generator/src/inversify/inversify-binding.ts
@@ -14,7 +14,10 @@ import { Container } from 'inversify';
 import { devfileModule } from '../devfile/devfile-module';
 import { fetchModule } from '../fetch/fetch-module';
 import { githubModule } from '../github/github-module';
+import { resolveModule } from '../resolve/resolve-module';
 import { pluginRegistryModule } from '../plugin-registry/plugin-registry-module';
+import { bitbucketModule } from '../bitbucket/bitbucket-module';
+import { bitbucketServerModule } from '../bitbucket-server/bitbucket-server-module';
 
 /**
  * Manage all bindings for inversify
@@ -28,6 +31,9 @@ export class InversifyBinding {
     this.container.load(devfileModule);
     this.container.load(fetchModule);
     this.container.load(githubModule);
+    this.container.load(bitbucketModule);
+    this.container.load(bitbucketServerModule);
+    this.container.load(resolveModule);
     this.container.load(pluginRegistryModule);
 
     this.container.bind(Symbol.for('AxiosInstance')).toConstantValue(options.axiosInstance);

--- a/tools/devworkspace-generator/src/main.ts
+++ b/tools/devworkspace-generator/src/main.ts
@@ -72,8 +72,6 @@ export class Main {
 
     // gets the repo URL
     if (params.devfileUrl) {
-      // const githubResolver = container.get(GithubResolver);
-      // const githubUrl = githubResolver.resolve(params.devfileUrl);
       const resolver = container.get(GitUrlResolver);
       const url = resolver.resolve(params.devfileUrl);
       // user devfile

--- a/tools/devworkspace-generator/src/main.ts
+++ b/tools/devworkspace-generator/src/main.ts
@@ -18,6 +18,7 @@ import { UrlFetcher } from './fetch/url-fetcher';
 import { PluginRegistryResolver } from './plugin-registry/plugin-registry-resolver';
 import { V1alpha2DevWorkspaceSpecTemplate } from '@devfile/api';
 import { DevfileContext } from './api/devfile-context';
+import { GitUrlResolver } from './resolve/git-url-resolver';
 
 export class Main {
   /**
@@ -69,12 +70,14 @@ export class Main {
     let devfileContent;
     let editorContent;
 
-    // gets the github URL
+    // gets the repo URL
     if (params.devfileUrl) {
-      const githubResolver = container.get(GithubResolver);
-      const githubUrl = githubResolver.resolve(params.devfileUrl);
+      // const githubResolver = container.get(GithubResolver);
+      // const githubUrl = githubResolver.resolve(params.devfileUrl);
+      const resolver = container.get(GitUrlResolver);
+      const url = resolver.resolve(params.devfileUrl);
       // user devfile
-      devfileContent = await container.get(UrlFetcher).fetchText(githubUrl.getContentUrl('devfile.yaml'));
+      devfileContent = await container.get(UrlFetcher).fetchText(url.getContentUrl('devfile.yaml'));
 
       // load content
       const devfileParsed = jsYaml.load(devfileContent);
@@ -84,10 +87,10 @@ export class Main {
         // no, so add the current project being cloned
         devfileParsed.projects = [
           {
-            name: githubUrl.getRepoName(),
+            name: url.getRepoName(),
             git: {
-              remotes: { origin: githubUrl.getCloneUrl() },
-              checkoutFrom: { revision: githubUrl.getBranchName() },
+              remotes: { origin: url.getCloneUrl() },
+              checkoutFrom: { revision: url.getBranchName() },
             },
           },
         ];

--- a/tools/devworkspace-generator/src/resolve/git-url-resolver.ts
+++ b/tools/devworkspace-generator/src/resolve/git-url-resolver.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import { injectable, multiInject } from 'inversify';
+import { Url } from './url';
+import { TYPES } from '../types';
+import { Resolver } from './resolver';
+
+const { Resolver } = TYPES;
+
+@injectable()
+export class GitUrlResolver {
+  @multiInject(Resolver)
+  private resolvers: Resolver[];
+
+  resolve(link: string): Url {
+    const resolver = this.resolvers.find(r => r.isValid(link));
+    if (resolver) {
+      return resolver.resolve(link);
+    } else {
+      throw new Error('Can not resolver the URL');
+    }
+  }
+}

--- a/tools/devworkspace-generator/src/resolve/resolve-module.ts
+++ b/tools/devworkspace-generator/src/resolve/resolve-module.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2023 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,13 +9,10 @@
  ***********************************************************************/
 import { ContainerModule, interfaces } from 'inversify';
 
-import { GithubResolver } from './github-resolver';
-import { TYPES } from '../types';
+import { GitUrlResolver } from './git-url-resolver';
 
-const { Resolver } = TYPES;
-
-const githubModule = new ContainerModule((bind: interfaces.Bind) => {
-  bind(Resolver).to(GithubResolver).inSingletonScope();
+const resolveModule = new ContainerModule((bind: interfaces.Bind) => {
+  bind(GitUrlResolver).toSelf().inSingletonScope();
 });
 
-export { githubModule };
+export { resolveModule };

--- a/tools/devworkspace-generator/src/resolve/resolver.ts
+++ b/tools/devworkspace-generator/src/resolve/resolver.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { Url } from './url';
+
+export interface Resolver {
+  /**
+   * Validates the string url for belonging to a specific Git provider.
+   * @param url string representation of Url.
+   */
+  isValid(url: string): boolean;
+
+  /**
+   * Resolves repository string URL to a {@class Url} object.
+   * @param url string representation of Url.
+   */
+  resolve(url: string): Url;
+}

--- a/tools/devworkspace-generator/src/resolve/url.ts
+++ b/tools/devworkspace-generator/src/resolve/url.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2023 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/tools/devworkspace-generator/src/resolve/url.ts
+++ b/tools/devworkspace-generator/src/resolve/url.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/**
+ * Url object
+ */
+export interface Url {
+  /**
+   * Provides RAW file content url
+   * @param path file path
+   */
+  getContentUrl(path: string);
+
+  /**
+   * Provides repositories Url
+   */
+  getUrl(): string;
+
+  /**
+   * Provides Git clone url
+   */
+  getCloneUrl(): string;
+
+  /**
+   * Provides repository name
+   */
+  getRepoName(): string;
+
+  /**
+   * Provides branch name if initialised.
+   */
+  getBranchName(): string;
+}

--- a/tools/devworkspace-generator/src/types.ts
+++ b/tools/devworkspace-generator/src/types.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2023 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -7,15 +7,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
-import { ContainerModule, interfaces } from 'inversify';
+const TYPES = {
+  Resolver: Symbol.for('Resolver'),
+};
 
-import { GithubResolver } from './github-resolver';
-import { TYPES } from '../types';
-
-const { Resolver } = TYPES;
-
-const githubModule = new ContainerModule((bind: interfaces.Bind) => {
-  bind(Resolver).to(GithubResolver).inSingletonScope();
-});
-
-export { githubModule };
+export { TYPES };

--- a/tools/devworkspace-generator/tests/bitbucket-server/bitbucket-server-resolver.spec.ts
+++ b/tools/devworkspace-generator/tests/bitbucket-server/bitbucket-server-resolver.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2023 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/tools/devworkspace-generator/tests/bitbucket-server/bitbucket-server-resolver.spec.ts
+++ b/tools/devworkspace-generator/tests/bitbucket-server/bitbucket-server-resolver.spec.ts
@@ -11,7 +11,7 @@
 import 'reflect-metadata';
 
 import { Container } from 'inversify';
-import { BitbucketServerResolver } from '../../lib/bitbucket-server/bitbucket-server-resolver';
+import { BitbucketServerResolver } from '../../src/bitbucket-server/bitbucket-server-resolver';
 
 describe('Test Bitbucket resolver', () => {
   let container: Container;

--- a/tools/devworkspace-generator/tests/bitbucket-server/bitbucket-server-resolver.spec.ts
+++ b/tools/devworkspace-generator/tests/bitbucket-server/bitbucket-server-resolver.spec.ts
@@ -1,0 +1,139 @@
+/**********************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { BitbucketServerResolver } from '../../lib/bitbucket-server/bitbucket-server-resolver';
+
+describe('Test Bitbucket resolver', () => {
+  let container: Container;
+
+  let bitbucketResolver: BitbucketServerResolver;
+
+  const BITBUCKET_SERVER_URL = 'https://custom-bitbucket.com/';
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(BitbucketServerResolver).toSelf().inSingletonScope();
+    bitbucketResolver = container.get(BitbucketServerResolver);
+  });
+
+  test('test get Url', async () => {
+    const userUrl = BITBUCKET_SERVER_URL + 'users/user/repos/repo';
+    const projectUrl = BITBUCKET_SERVER_URL + 'projects/project/repos/repo';
+    const array = [
+      [BITBUCKET_SERVER_URL + 'scm/~user/repo.git', userUrl],
+      [BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse', userUrl],
+      [BITBUCKET_SERVER_URL + 'scm/project/repo.git', projectUrl],
+      [BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse', projectUrl],
+      [
+        BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=branch',
+        BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=branch',
+      ],
+      [
+        BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=refs%2Fheads%2Fbranch',
+        BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=branch',
+      ],
+      [
+        BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse?at=branch',
+        BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse?at=branch',
+      ],
+    ];
+    array.forEach(a => expect(bitbucketResolver.resolve(a[0]).getUrl()).toBe(a[1]));
+  });
+
+  test('test get clone Url', async () => {
+    const userUrl = BITBUCKET_SERVER_URL + 'scm/~user/repo.git';
+    const projectUrl = BITBUCKET_SERVER_URL + 'scm/project/repo.git';
+    const array = [
+      [BITBUCKET_SERVER_URL + 'scm/~user/repo.git', userUrl],
+      [BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse', userUrl],
+      [BITBUCKET_SERVER_URL + 'scm/project/repo.git', projectUrl],
+      [BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse', projectUrl],
+      [BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=branch', userUrl],
+      [BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=refs%2Fheads%2Fbranch', userUrl],
+      [BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse?at=branch', projectUrl],
+    ];
+    array.forEach(a => expect(bitbucketResolver.resolve(a[0]).getCloneUrl()).toBe(a[1]));
+  });
+
+  test('test get content', async () => {
+    const userUrl = BITBUCKET_SERVER_URL + 'users/user/repos/repo/raw/README.md';
+    const projectUrl = BITBUCKET_SERVER_URL + 'projects/project/repos/repo/raw/README.md';
+    const array = [
+      [BITBUCKET_SERVER_URL + 'scm/~user/repo.git', userUrl],
+      [BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse', userUrl],
+      [BITBUCKET_SERVER_URL + 'scm/project/repo.git', projectUrl],
+      [BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse', projectUrl],
+      [
+        BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=branch',
+        BITBUCKET_SERVER_URL + 'users/user/repos/repo/raw/README.md?/at=branch',
+      ],
+      [
+        BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=refs%2Fheads%2Fbranch',
+        BITBUCKET_SERVER_URL + 'users/user/repos/repo/raw/README.md?/at=branch',
+      ],
+      [
+        BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse?at=branch',
+        BITBUCKET_SERVER_URL + 'projects/project/repos/repo/raw/README.md?/at=branch',
+      ],
+    ];
+    array.forEach(a => expect(bitbucketResolver.resolve(a[0]).getContentUrl('README.md')).toBe(a[1]));
+  });
+
+  test('test get branch', async () => {
+    expect(
+      bitbucketResolver.resolve(BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=branch').getBranchName()
+    ).toBe('branch');
+    expect(
+      bitbucketResolver
+        .resolve(BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=refs%2Fheads%2Fbranch')
+        .getBranchName()
+    ).toBe('branch');
+    expect(
+      bitbucketResolver.resolve(BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse?at=branch').getBranchName()
+    ).toBe('branch');
+  });
+
+  test('test get repository', async () => {
+    const array = [
+      BITBUCKET_SERVER_URL + 'scm/~user/repo.git',
+      BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse',
+      BITBUCKET_SERVER_URL + 'scm/project/repo.git',
+      BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse',
+      BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=branch',
+      BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=refs%2Fheads%2Fbranch',
+      BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse?at=branch',
+    ];
+    array.forEach(a => expect(bitbucketResolver.resolve(a).getRepoName()).toBe('repo'));
+  });
+
+  test('validate URL', async () => {
+    const array = [
+      BITBUCKET_SERVER_URL + 'scm/~user/repo.git',
+      BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse',
+      BITBUCKET_SERVER_URL + 'scm/project/repo.git',
+      BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse',
+      BITBUCKET_SERVER_URL + 'users/user/repos/repo/browse?at=branch',
+      BITBUCKET_SERVER_URL + 'projects/project/repos/repo/browse?at=branch',
+    ];
+    array.forEach(a => expect(bitbucketResolver.isValid(a)).toBeTruthy());
+    expect(bitbucketResolver.isValid('https://github.com/user/repo')).toBeFalsy();
+  });
+
+  test('error', async () => {
+    expect(() => {
+      bitbucketResolver.resolve('http://unknown/che');
+    }).toThrow('Invalid bitbucket-server URL:');
+  });
+});

--- a/tools/devworkspace-generator/tests/bitbucket/bitbucket-resolver.spec.ts
+++ b/tools/devworkspace-generator/tests/bitbucket/bitbucket-resolver.spec.ts
@@ -11,7 +11,7 @@
 import 'reflect-metadata';
 
 import { Container } from 'inversify';
-import { BitbucketResolver } from '../../lib/bitbucket/bitbucket-resolver';
+import { BitbucketResolver } from '../../src/bitbucket/bitbucket-resolver';
 
 describe('Test Bitbucket resolver', () => {
   let container: Container;

--- a/tools/devworkspace-generator/tests/bitbucket/bitbucket-resolver.spec.ts
+++ b/tools/devworkspace-generator/tests/bitbucket/bitbucket-resolver.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2023 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/tools/devworkspace-generator/tests/bitbucket/bitbucket-resolver.spec.ts
+++ b/tools/devworkspace-generator/tests/bitbucket/bitbucket-resolver.spec.ts
@@ -1,0 +1,101 @@
+/**********************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { BitbucketResolver } from '../../lib/bitbucket/bitbucket-resolver';
+
+describe('Test Bitbucket resolver', () => {
+  let container: Container;
+
+  let bitbucketResolver: BitbucketResolver;
+
+  const BITBUCKET_URL = 'https://bitbucket.org/workspace/repo';
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(BitbucketResolver).toSelf().inSingletonScope();
+    bitbucketResolver = container.get(BitbucketResolver);
+  });
+
+  test('test get Url', async () => {
+    const array = [
+      ['https://user@bitbucket.org/workspace/repo.git', 'https://bitbucket.org/workspace/repo/src/HEAD'],
+      [BITBUCKET_URL, 'https://bitbucket.org/workspace/repo/src/HEAD'],
+      [BITBUCKET_URL + '/', 'https://bitbucket.org/workspace/repo/src/HEAD'],
+      [BITBUCKET_URL + '/src/branch', 'https://bitbucket.org/workspace/repo/src/branch'],
+      [BITBUCKET_URL + '/src/branch/', 'https://bitbucket.org/workspace/repo/src/branch'],
+    ];
+    array.forEach(a => expect(bitbucketResolver.resolve(a[0]).getUrl()).toBe(a[1]));
+  });
+
+  test('test get clone Url', async () => {
+    const url = 'https://bitbucket.org/workspace/repo.git';
+    const array = [
+      ['https://user@bitbucket.org/workspace/repo.git', url],
+      [BITBUCKET_URL, url],
+      [BITBUCKET_URL + '/', url],
+      [BITBUCKET_URL + '/src/branch', url],
+      [BITBUCKET_URL + '/src/branch/', url],
+    ];
+    array.forEach(a => expect(bitbucketResolver.resolve(a[0]).getCloneUrl()).toBe(a[1]));
+  });
+
+  test('test get content Url', async () => {
+    const url = 'https://bitbucket.org/workspace/repo/raw/HEAD/Readme.md';
+    const array = [
+      ['https://user@bitbucket.org/workspace/repo.git', url],
+      [BITBUCKET_URL, url],
+      [BITBUCKET_URL + '/', url],
+      [BITBUCKET_URL + '/src/branch', 'https://bitbucket.org/workspace/repo/raw/branch/Readme.md'],
+      [BITBUCKET_URL + '/src/branch/', 'https://bitbucket.org/workspace/repo/raw/branch/Readme.md'],
+    ];
+    array.forEach(a => expect(bitbucketResolver.resolve(a[0]).getContentUrl('Readme.md')).toBe(a[1]));
+  });
+
+  test('test get branch', async () => {
+    expect(bitbucketResolver.resolve('https://bitbucket.org/workspace/repo/src/branch').getBranchName()).toBe('branch');
+    expect(bitbucketResolver.resolve('https://bitbucket.org/workspace/repo/src/branch/').getBranchName()).toBe(
+      'branch'
+    );
+  });
+
+  test('test get repository', async () => {
+    const array = [
+      'https://user@bitbucket.org/workspace/repo.git',
+      BITBUCKET_URL,
+      BITBUCKET_URL + '/',
+      BITBUCKET_URL + '/src/branch',
+      BITBUCKET_URL + '/src/branch/',
+    ];
+    array.forEach(a => expect(bitbucketResolver.resolve(a).getRepoName()).toBe('repo'));
+  });
+
+  test('validate URL', async () => {
+    const array = [
+      'https://user@bitbucket.org/workspace/repo.git',
+      BITBUCKET_URL,
+      BITBUCKET_URL + '/',
+      BITBUCKET_URL + '/src/branch',
+      BITBUCKET_URL + '/src/branch/',
+    ];
+    array.forEach(a => expect(bitbucketResolver.isValid(a)).toBeTruthy());
+    expect(bitbucketResolver.isValid('https://github.com/user/repo')).toBeFalsy();
+  });
+
+  test('error', async () => {
+    expect(() => {
+      bitbucketResolver.resolve('http://unknown/che');
+    }).toThrow('Invalid bitbucket URL:');
+  });
+});

--- a/tools/devworkspace-generator/tests/inversify/inversify-binding.spec.ts
+++ b/tools/devworkspace-generator/tests/inversify/inversify-binding.spec.ts
@@ -20,6 +20,7 @@ import { UrlFetcher } from '../../src/fetch/url-fetcher';
 import { GithubResolver } from '../../src/github/github-resolver';
 import { PluginRegistryResolver } from '../../src/plugin-registry/plugin-registry-resolver';
 import { DevContainerComponentFinder } from '../../src/devfile/dev-container-component-finder';
+import { TYPES } from '../../src/types';
 
 describe('Test InversifyBinding', () => {
   const mockedArgv: string[] = ['dummy', 'dummy'];
@@ -53,8 +54,8 @@ describe('Test InversifyBinding', () => {
     // check fetch module
     expect(container.get(UrlFetcher)).toBeDefined();
 
-    // check github module
-    expect(container.get(GithubResolver)).toBeDefined();
+    // check resolve module
+    expect(container.getAll(TYPES.Resolver).length).toBe(3);
 
     // check plugin-registry module
     expect(container.get(PluginRegistryResolver)).toBeDefined();

--- a/tools/devworkspace-generator/tests/resolve/git-url-resolver.spec.ts
+++ b/tools/devworkspace-generator/tests/resolve/git-url-resolver.spec.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container, injectable } from 'inversify';
+import { GitUrlResolver } from '../../src/resolve/git-url-resolver';
+import { TYPES } from '../../src/types';
+
+describe('Test git Url resolver', () => {
+  let container: Container;
+
+  let urlResolver: GitUrlResolver;
+
+  const resolveMock = jest.fn();
+  const isValidMock = jest.fn();
+  const resolver = {
+    resolve: resolveMock,
+    isValid: isValidMock,
+  } as any;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(GitUrlResolver).toSelf().inSingletonScope();
+    container.bind(TYPES.Resolver).toConstantValue(resolver);
+    urlResolver = container.get(GitUrlResolver);
+  });
+
+  test('test url resolver', async () => {
+    isValidMock.mockReturnValue(true);
+
+    urlResolver.resolve('test');
+
+    expect(resolveMock).toBeCalledWith('test');
+  });
+
+  test('test resolver failure', async () => {
+    isValidMock.mockReturnValue(false);
+
+    expect(() => urlResolver.resolve('test')).toThrow('Can not resolver the URL');
+  });
+});

--- a/tools/devworkspace-generator/tests/resolve/git-url-resolver.spec.ts
+++ b/tools/devworkspace-generator/tests/resolve/git-url-resolver.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2023 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add Bitbucket and Bitbucket Server support

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4323

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Deploy bitbucket server: https://github.com/che-incubator/git-srv/tree/main/bitbucket.
2. Create a repository with a devfile in the bitbucket server instance.
3. Go to projects directory: '/tools/devworkspace-generator' directory
4. execute `yarn`
5. execute 
```bash
node lib/entrypoint.js \
        --plugin-registry-url:https://che-plugin-registry-main.surge.sh/v3/ \
        --editor-entry:che-incubator/che-code/latest \
        --output-file:<output directory> \
        --injectDefaultComponent:true \
        --defaultComponentImage:registry.access.redhat.com/ubi8/openjdk-11:latest \
        --devfile-url:<url of the bitbucket server repo>
```
See: `yaml` file is generated and contains the devfile from the repository.
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
