### PR TITLE
feat: don't add merge-contribution attribute into the dev container

### DIFF
--- a/tools/devworkspace-generator/src/generate.ts
+++ b/tools/devworkspace-generator/src/generate.ts
@@ -31,8 +31,6 @@ type DevfileLike = V221Devfile & {
 
 @injectable()
 export class Generate {
-  static readonly MERGE_CONTRIBUTION = 'controller.devfile.io/merge-contribution';
-
   @inject(DevContainerComponentFinder)
   private devContainerComponentFinder: DevContainerComponentFinder;
 

--- a/tools/devworkspace-generator/src/generate.ts
+++ b/tools/devworkspace-generator/src/generate.ts
@@ -14,7 +14,6 @@ import {
   V1alpha2DevWorkspace,
   V1alpha2DevWorkspaceMetadata,
   V1alpha2DevWorkspaceSpecContributions,
-  V1alpha2DevWorkspaceSpecTemplateComponents,
   V1alpha2DevWorkspaceTemplate,
   V1alpha2DevWorkspaceTemplateSpec,
 } from '@devfile/api';
@@ -127,23 +126,8 @@ export class Generate {
       suffix,
     };
 
-    // grab container where to inject controller.devfile.io/merge-contribution attribute
-    let devContainer: V1alpha2DevWorkspaceSpecTemplateComponents | undefined =
-      await this.devContainerComponentFinder.find(context, injectDefaultComponent, defaultComponentImage);
-
-    if (!devContainer) {
-      return context;
-    }
-
-    // add attributes
-    let devContainerAttributes = devContainer.attributes;
-    if (!devContainerAttributes) {
-      devContainerAttributes = {};
-      devContainerAttributes[Generate.MERGE_CONTRIBUTION] = true;
-      devContainer.attributes = devContainerAttributes;
-    } else {
-      devContainerAttributes[Generate.MERGE_CONTRIBUTION] = true;
-    }
+    // find devContainer component, add a default one if not found
+    await this.devContainerComponentFinder.find(context, injectDefaultComponent, defaultComponentImage);
 
     return context;
   }

--- a/tools/devworkspace-generator/tests/generate.spec.ts
+++ b/tools/devworkspace-generator/tests/generate.spec.ts
@@ -119,7 +119,7 @@ metadata:
       // expect not to write the file
       expect(fsWriteFileSpy).not.toBeCalled();
       expect(JSON.stringify(context.devfile)).toEqual(
-        '{"schemaVersion":"2.2.0","metadata":{"name":"my-dummy-project"},"components":[{"name":"dev-container","mountSources":true,"container":{"image":"quay.io/foo/bar"},"attributes":{"controller.devfile.io/merge-contribution":true}}]}'
+        '{"schemaVersion":"2.2.0","metadata":{"name":"my-dummy-project"},"components":[{"name":"dev-container","mountSources":true,"container":{"image":"quay.io/foo/bar"}}]}'
       );
       const expectedDevWorkspace = {
         apiVersion: 'workspace.devfile.io/v1alpha2',
@@ -140,9 +140,6 @@ metadata:
                 mountSources: true,
                 container: {
                   image: 'quay.io/foo/bar',
-                },
-                attributes: {
-                  'controller.devfile.io/merge-contribution': true,
                 },
               },
             ],
@@ -189,7 +186,7 @@ metadata:
       // expect not to write the file
       expect(fsWriteFileSpy).not.toBeCalled();
       expect(JSON.stringify(context.devfile)).toEqual(
-        '{"schemaVersion":"2.2.0","metadata":{"generateName":"custom-project"},"components":[{"name":"dev-container","mountSources":true,"container":{"image":"quay.io/foo/bar"},"attributes":{"controller.devfile.io/merge-contribution":true}}]}'
+        '{"schemaVersion":"2.2.0","metadata":{"generateName":"custom-project"},"components":[{"name":"dev-container","mountSources":true,"container":{"image":"quay.io/foo/bar"}}]}'
       );
       const expectedDevWorkspace = {
         apiVersion: 'workspace.devfile.io/v1alpha2',
@@ -210,9 +207,6 @@ metadata:
                 mountSources: true,
                 container: {
                   image: 'quay.io/foo/bar',
-                },
-                attributes: {
-                  'controller.devfile.io/merge-contribution': true,
                 },
               },
             ],
@@ -260,7 +254,7 @@ metadata:
       // expect to write the file
       expect(fsWriteFileSpy).toBeCalled();
       expect(JSON.stringify(context.devfile)).toEqual(
-        '{"schemaVersion":"2.2.0","metadata":{"name":"my-dummy-project"},"components":[{"name":"dev-container","mountSources":true,"container":{"image":"quay.io/foo/bar"},"attributes":{"controller.devfile.io/merge-contribution":true}}]}'
+        '{"schemaVersion":"2.2.0","metadata":{"name":"my-dummy-project"},"components":[{"name":"dev-container","mountSources":true,"container":{"image":"quay.io/foo/bar"}}]}'
       );
       const expectedDevWorkspace = {
         apiVersion: 'workspace.devfile.io/v1alpha2',
@@ -281,9 +275,6 @@ metadata:
                 mountSources: true,
                 container: {
                   image: 'quay.io/foo/bar',
-                },
-                attributes: {
-                  'controller.devfile.io/merge-contribution': true,
                 },
               },
             ],
@@ -331,7 +322,7 @@ metadata:
       // expect to write the file
       expect(fsWriteFileSpy).toBeCalled();
       expect(JSON.stringify(context.devfile)).toEqual(
-        '{"schemaVersion":"2.2.0","metadata":{"name":"my-dummy-project"},"components":[{"name":"dev-container","attributes":{"old":"attribute","controller.devfile.io/merge-contribution":true},"mountSources":true,"container":{"image":"quay.io/foo/bar"}}]}'
+        '{"schemaVersion":"2.2.0","metadata":{"name":"my-dummy-project"},"components":[{"name":"dev-container","attributes":{"old":"attribute"},"mountSources":true,"container":{"image":"quay.io/foo/bar"}}]}'
       );
       const expectedDevWorkspace = {
         apiVersion: 'workspace.devfile.io/v1alpha2',
@@ -351,7 +342,6 @@ metadata:
                 name: 'dev-container',
                 attributes: {
                   old: 'attribute',
-                  'controller.devfile.io/merge-contribution': true,
                 },
                 mountSources: true,
                 container: {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Update the generator to avoid adding **controller.devfile.io/merge-contribution** attribute into the developer container, it will be done by the DWO

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22155

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1/ Go to che-devfile-registry/tools/devworkspace-generator
2/ Build the tool by running yarn
3/ Generate a devworkspace:
```
node lib/entrypoint.js \
        --devfile-url:https://github.com/che-samples/java-spring-petclinic/tree/main \
        --plugin-registry-url:https://che-plugin-registry-main.surge.sh/v3/ \
        --editor-entry:che-incubator/che-code/latest \
        --output-file:/tmp/devworkspace-che-code-latest.yaml 
```
4/ Take a look at the generated file /tmp/devworkspace-che-code-latest.yaml, it should not contain **controller.devfile.io/merge-contribution** attribute in the components.

5/ Try to start a workspace using generated file by executing `oc apply -f  /tmp/devworkspace-che-code-latest.yaml`, workspace should be started. 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
