### PR TITLE
feat: add an attribute with starterProject to the devworkspace

### DIFF
--- a/tools/devworkspace-generator/src/generate.ts
+++ b/tools/devworkspace-generator/src/generate.ts
@@ -16,7 +16,6 @@ import {
   V1alpha2DevWorkspaceSpecContributions,
   V1alpha2DevWorkspaceTemplate,
   V1alpha2DevWorkspaceTemplateSpec,
-  V221DevfileStarterProjects,
 } from '@devfile/api';
 import { injectable, inject } from 'inversify';
 import * as jsYaml from 'js-yaml';

--- a/tools/devworkspace-generator/src/generate.ts
+++ b/tools/devworkspace-generator/src/generate.ts
@@ -23,7 +23,6 @@ import * as jsYaml from 'js-yaml';
 import * as fs from 'fs-extra';
 import { DevfileContext } from './api/devfile-context';
 import { DevContainerComponentFinder } from './devfile/dev-container-component-finder';
-import { UrlFetcher } from './fetch/url-fetcher';
 
 type DevfileLike = V221Devfile & {
   metadata: V221DevfileMetadata & {
@@ -35,8 +34,6 @@ type DevfileLike = V221Devfile & {
 export class Generate {
   @inject(DevContainerComponentFinder)
   private devContainerComponentFinder: DevContainerComponentFinder;
-  @inject(UrlFetcher)
-  private urlFetcher: UrlFetcher;
 
   async generate(
     devfileContent: string,

--- a/tools/devworkspace-generator/src/generate.ts
+++ b/tools/devworkspace-generator/src/generate.ts
@@ -115,15 +115,10 @@ export class Generate {
       },
     };
 
-    let starterProjects: V221DevfileStarterProjects[];
-
     // if the devfile has a starter project, we use it for the devWorkspace
     if (devfileCopy.starterProjects && devfileCopy.starterProjects.length > 0) {
-      starterProjects = devfileCopy.starterProjects;
-      let starterProject: V221DevfileStarterProjects;
-      starterProject = starterProjects[0];
       devWorkspace.spec.template.attributes = {
-        'controller.devfile.io/use-starter-project': starterProject.name,
+        'controller.devfile.io/use-starter-project': devfileCopy.starterProjects[0].name,
       };
     }
 

--- a/tools/devworkspace-generator/tests/generate.spec.ts
+++ b/tools/devworkspace-generator/tests/generate.spec.ts
@@ -15,19 +15,11 @@ import { Container } from 'inversify';
 import { Generate } from '../src/generate';
 import { DevContainerComponentFinder } from '../src/devfile/dev-container-component-finder';
 import { DevContainerComponentInserter } from '../src/devfile/dev-container-component-inserter';
-import { UrlFetcher } from '../src/fetch/url-fetcher';
 
 describe('Test Generate', () => {
   let container: Container;
   let generate: Generate;
   let devContainerFinder: DevContainerComponentFinder;
-
-  const urlFetcherFetchTextMock = jest.fn();
-  const urlFetcherFetchTextOptionalMock = jest.fn();
-  const urlFetcher = {
-    fetchText: urlFetcherFetchTextMock,
-    fetchTextOptionalContent: urlFetcherFetchTextOptionalMock,
-  } as any;
 
   beforeEach(() => {
     jest.restoreAllMocks();
@@ -36,7 +28,6 @@ describe('Test Generate', () => {
     container.bind(Generate).toSelf().inSingletonScope();
     container.bind(DevContainerComponentFinder).toSelf().inSingletonScope();
     container.bind(DevContainerComponentInserter).toSelf().inSingletonScope();
-    container.bind(UrlFetcher).toConstantValue(urlFetcher);
     generate = container.get(Generate);
     devContainerFinder = container.get(DevContainerComponentFinder);
   });


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add a logic to analyze a original devfile if it contains a section with `starterProjects`  into devworkspace generator tool. If it contains, we add `controller.devfile.io/use-starter-project` attribute with value that describes the name of the project:
```
spec:
  template:
    attributes:
      controller.devfile.io/use-starter-project: name-of-the-project
```
After applying generated devworkspace the project should be cloned into the workspace and should be available in the Project tree.

An example of the generated devworkspace:

<details>
  <summary>Original devfile:</summary> 

```yaml
schemaVersion: 2.1.0
metadata:
  name: nodejs-svelte
  displayName: Svelte
  description: "Svelte is a radical new approach to building user interfaces.
    Whereas traditional frameworks like React and Vue do the bulk of their work in the browser, Svelte shifts that work into a compile step that happens when you build your app."
  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/svelte.svg
  tags:
    - Node.js
    - Svelte
  projectType: Svelte
  language: TypeScript
  provider: Red Hat
  version: 1.0.3
starterProjects:
  - name: nodejs-svelte-starter
    git:
      checkoutFrom:
        revision: main
      remotes:
        origin: https://github.com/devfile-samples/devfile-stack-nodejs-svelte.git
components:
  - container:
      endpoints:
        - name: http-svelte
          targetPort: 3000
      image: registry.access.redhat.com/ubi8/nodejs-16:1-105.1684740145
      args: ['tail', '-f', '/dev/null']
      memoryLimit: 1024Mi
    name: runtime
commands:
  - exec:
      commandLine: npm install
      component: runtime
      group:
        isDefault: true
        kind: build
      workingDir: ${PROJECT_SOURCE}
    id: install
  - exec:
      commandLine: npm run dev
      component: runtime
      group:
        isDefault: true
        kind: run
      workingDir: ${PROJECT_SOURCE}
    id: run
```

</details>

<details>
  <summary>Resulted devworkspace:</summary> 

```yaml
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspaceTemplate
metadata:
  name: che-code-nodejs-svelte
spec:
  commands:
    - id: init-container-command
      apply:
        component: che-code-injector
    - id: init-che-code-command
      exec:
        component: che-code-runtime-description
        commandLine: >-
          nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt
          2>&1 &
  events:
    preStart:
      - init-container-command
    postStart:
      - init-che-code-command
  components:
    - name: che-code-runtime-description
      container:
        image: >-
          quay.io/devfile/universal-developer-image@sha256:1158f026aa2231cf451ecfdca817ecda7f0e9b18db766195c3f0a4de08494a47
        volumeMounts:
          - name: checode
            path: /checode
        memoryLimit: 1024Mi
        memoryRequest: 256Mi
        cpuLimit: 500m
        cpuRequest: 30m
        endpoints:
          - name: che-code
            attributes:
              type: main
              cookiesAuthEnabled: true
              discoverable: false
              urlRewriteSupported: true
            targetPort: 3100
            exposure: public
            secure: false
            protocol: https
          - name: code-redirect-1
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13131
            exposure: public
            protocol: http
          - name: code-redirect-2
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13132
            exposure: public
            protocol: http
          - name: code-redirect-3
            attributes:
              discoverable: false
              urlRewriteSupported: false
            targetPort: 13133
            exposure: public
            protocol: http
      attributes:
        app.kubernetes.io/component: che-code-runtime
        app.kubernetes.io/part-of: che-code.eclipse.org
        controller.devfile.io/container-contribution: true
    - name: checode
      volume: {}
    - name: che-code-injector
      container:
        image: >-
          quay.io/che-incubator/che-code@sha256:857079b48678762a3cf5afe22694e634c98d6d3b58148436b88945938d5d24e5
        command:
          - /entrypoint-init-container.sh
        volumeMounts:
          - name: checode
            path: /checode
        memoryLimit: 256Mi
        memoryRequest: 32Mi
        cpuLimit: 500m
        cpuRequest: 30m
---
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: nodejs-svelte
  annotations:
    che.eclipse.org/devfile: |
      schemaVersion: 2.1.0
      metadata:
        name: nodejs-svelte
        displayName: Svelte
        description: >-
          Svelte is a radical new approach to building user interfaces. Whereas
          traditional frameworks like React and Vue do the bulk of their work in the
          browser, Svelte shifts that work into a compile step that happens when you
          build your app.
        icon: >-
          https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/svelte.svg
        tags:
          - Node.js
          - Svelte
        projectType: Svelte
        language: TypeScript
        provider: Red Hat
        version: 1.0.3
      starterProjects:
        - name: nodejs-svelte-starter
          git:
            checkoutFrom:
              revision: main
            remotes:
              origin: https://github.com/devfile-samples/devfile-stack-nodejs-svelte.git
      components:
        - container:
            endpoints:
              - name: http-svelte
                targetPort: 3000
            image: registry.access.redhat.com/ubi8/nodejs-16:1-105.1684740145
            args:
              - tail
              - '-f'
              - /dev/null
            memoryLimit: 1024Mi
          name: runtime
      commands:
        - exec:
            commandLine: npm install
            component: runtime
            group:
              isDefault: true
              kind: build
            workingDir: ${PROJECT_SOURCE}
          id: install
        - exec:
            commandLine: npm run dev
            component: runtime
            group:
              isDefault: true
              kind: run
            workingDir: ${PROJECT_SOURCE}
          id: run
spec:
  started: true
  routingClass: che
  template:
    starterProjects:
      - name: nodejs-svelte-starter
        git:
          checkoutFrom:
            revision: main
          remotes:
            origin: https://github.com/devfile-samples/devfile-stack-nodejs-svelte.git
    components:
      - container:
          endpoints:
            - name: http-svelte
              targetPort: 3000
          image: registry.access.redhat.com/ubi8/nodejs-16:1-105.1684740145
          args:
            - tail
            - '-f'
            - /dev/null
          memoryLimit: 1024Mi
        name: runtime
    commands:
      - exec:
          commandLine: npm install
          component: runtime
          group:
            isDefault: true
            kind: build
          workingDir: ${PROJECT_SOURCE}
        id: install
      - exec:
          commandLine: npm run dev
          component: runtime
          group:
            isDefault: true
            kind: run
          workingDir: ${PROJECT_SOURCE}
        id: run
    attributes:
      controller.devfile.io/use-starter-project: nodejs-svelte-starter
  contributions:
    - name: editor
      kubernetes:
        name: che-code-nodejs-svelte
```
</details>

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![screenshot-eclipse-che apps rosa qp5ra-b5547-2tx gkpc p3 openshiftapps com-2023 09 19-16_46_01](https://github.com/eclipse-che/che-devfile-registry/assets/1271546/b3e85a5b-edd5-4678-a576-ecf74f09ca2f)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22486

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
To test that the generated devworkspace is applicable, use the resulted devworkspace from the description and create a workspace by using `oc apply -f <path to the devworkspace>`

Or you can generate your own. To do that:
1. Build the generator tool with current changes
2. Go to `che-devfile-registry/tools/devworkspace-generator` and run 
```
node lib/entrypoint.js \         
        --devfile-path:path-to-original-devfile \
        --plugin-registry-url:https://che-plugin-registry-main.surge.sh/v3/ \
        --editor-entry:che-incubator/che-code/latest \
        --output-file:/tmp/devworkspace-che-code-latest.yaml
```
3. Use `oc apply -f /tmp/devworkspace-che-code-latest.yaml` to create a workspace
4. Check that the workspace is started and the sample is present in the Project tree.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
